### PR TITLE
Add local notes support to content detail pages

### DIFF
--- a/src/components/NotesPanel.astro
+++ b/src/components/NotesPanel.astro
@@ -32,6 +32,9 @@ const noteKey = `${contentType}:${contentId}`;
     <button type="button" class="primary" data-note-save>
       Save note
     </button>
+    <button type="button" class="secondary" data-note-clear>
+      Clear draft
+    </button>
     <button type="button" class="secondary" data-note-export>
       Export all notes
     </button>
@@ -46,6 +49,10 @@ const noteKey = `${contentType}:${contentId}`;
     <summary>Preview</summary>
     <div data-note-preview></div>
   </details>
+  <div class="note-history">
+    <h3>Saved notes</h3>
+    <ul class="note-list" data-note-list></ul>
+  </div>
 </section>
 
 <style>
@@ -106,11 +113,55 @@ const noteKey = `${contentType}:${contentId}`;
     white-space: pre-wrap;
     font-family: var(--pico-font-family-monospace, ui-monospace, SFMono-Regular, SFMono, "Roboto Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
   }
+
+  .note-history {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .note-history h3 {
+    margin: 0;
+  }
+
+  .note-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .note-item {
+    border: 1px solid var(--pico-muted-border-color, hsla(0, 0%, 100%, 0.1));
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    display: grid;
+    gap: 0.5rem;
+    background: var(--pico-card-background-color, rgba(255, 255, 255, 0.03));
+  }
+
+  .note-item__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .note-item__timestamp {
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+  }
+
+  .note-item__body {
+    margin: 0;
+    white-space: pre-wrap;
+  }
+
 </style>
 
 <script type="module" lang="ts">
   const STORAGE_NAMESPACE = "improv-toolbox:notes";
-  const STORAGE_VERSION = 1;
+  const STORAGE_VERSION = 2;
   const storageSupported = (() => {
     if (typeof window === "undefined" || !("localStorage" in window)) {
       return false;
@@ -144,10 +195,25 @@ const noteKey = `${contentType}:${contentId}`;
     const exportButton = /** @type {HTMLButtonElement | null} */ (
       panel.querySelector("[data-note-export]")
     );
+    const clearButton = /** @type {HTMLButtonElement | null} */ (
+      panel.querySelector("[data-note-clear]")
+    );
     const meta = /** @type {HTMLParagraphElement | null} */ (
       panel.querySelector("[data-note-meta]")
     );
-    if (!textarea || !preview || !status || !exportButton || !saveButton || !meta) {
+    const list = /** @type {HTMLUListElement | null} */ (
+      panel.querySelector("[data-note-list]")
+    );
+    if (
+      !textarea ||
+      !preview ||
+      !status ||
+      !exportButton ||
+      !saveButton ||
+      !meta ||
+      !list ||
+      !clearButton
+    ) {
       return;
     }
 
@@ -164,7 +230,60 @@ const noteKey = `${contentType}:${contentId}`;
      * @returns {NotesPayload}
      */
     function emptyNotesPayload() {
-      return { version: STORAGE_VERSION, notes: {} };
+      return { version: STORAGE_VERSION, notes: {}, drafts: {} };
+    }
+
+    /**
+     * @param {Partial<NotesPayloadLegacy>} payload
+     * @returns {NotesPayload}
+     */
+    function migratePayload(payload) {
+      if (
+        !payload ||
+        typeof payload !== "object" ||
+        typeof payload.notes !== "object" ||
+        payload.notes === null
+      ) {
+        return emptyNotesPayload();
+      }
+
+      if (payload.version === STORAGE_VERSION && "drafts" in payload) {
+        return /** @type {NotesPayload} */ (payload);
+      }
+
+      const migrated = emptyNotesPayload();
+      migrated.version = STORAGE_VERSION;
+
+      for (const [key, value] of Object.entries(payload.notes)) {
+        if (!value || typeof value !== "object") continue;
+        const items = [];
+        const content = typeof value.content === "string" ? value.content : "";
+        const updatedAt =
+          typeof value.updatedAt === "string"
+            ? value.updatedAt
+            : new Date().toISOString();
+        if (content.trim()) {
+          items.push({
+            id: `${key}:${updatedAt}`,
+            content,
+            savedAt: updatedAt,
+          });
+        } else if (content) {
+          migrated.drafts[key] = {
+            content,
+            updatedAt,
+          };
+        }
+        migrated.notes[key] = {
+          id: key,
+          type: typeof value.type === "string" ? value.type : "content",
+          title: typeof value.title === "string" ? value.title : "",
+          items,
+          updatedAt,
+        };
+      }
+
+      return migrated;
     }
 
     /**
@@ -178,15 +297,14 @@ const noteKey = `${contentType}:${contentId}`;
           return emptyNotesPayload();
         }
         const parsed = JSON.parse(raw);
-        if (
-          typeof parsed !== "object" ||
-          parsed === null ||
-          typeof parsed.version !== "number" ||
-          typeof parsed.notes !== "object"
-        ) {
-          return emptyNotesPayload();
+        const migrated = migratePayload(
+          /** @type {Partial<NotesPayloadLegacy>} */ (parsed)
+        );
+        if (migrated.version !== STORAGE_VERSION) {
+          migrated.version = STORAGE_VERSION;
+          persistAllNotes(migrated);
         }
-        return /** @type {NotesPayload} */ (parsed);
+        return migrated;
       } catch (error) {
         console.warn("Notes storage unavailable", error);
         storageReady = false;
@@ -207,42 +325,72 @@ const noteKey = `${contentType}:${contentId}`;
         setStatus("Saving failed: storage is unavailable.");
         textarea.setAttribute("readonly", "true");
         textarea.classList.add("note-field--readonly");
+        exportButton.setAttribute("disabled", "true");
+        saveButton.setAttribute("disabled", "true");
+        clearButton.setAttribute("disabled", "true");
       }
     }
 
-    /**
-     * @returns {NoteEntry}
-     */
-    function loadCurrentNote() {
+    function ensurePayload() {
       if (!notesPayload) {
         notesPayload = loadAllNotes();
       }
-      const existing = notesPayload.notes[noteKey];
-      if (existing) return existing;
-      return {
+      return notesPayload;
+    }
+
+    /**
+     * @returns {NoteCollection}
+     */
+    function loadCollection() {
+      const payload = ensurePayload();
+      const existing = payload.notes[noteKey];
+      if (existing) {
+        return existing;
+      }
+      const collection = {
         id: noteKey,
         type: noteType,
         title: noteTitle,
-        content: "",
+        items: [],
         updatedAt: new Date().toISOString(),
       };
+      payload.notes[noteKey] = collection;
+      return collection;
+    }
+
+    /**
+     * @returns {DraftEntry | null}
+     */
+    function loadDraft() {
+      const payload = ensurePayload();
+      return payload.drafts[noteKey] ?? null;
     }
 
     /**
      * @param {string} content
      */
-    function saveCurrentNote(content) {
-      if (!notesPayload) {
-        notesPayload = loadAllNotes();
+    function saveDraft(content) {
+      const payload = ensurePayload();
+      if (!content) {
+        delete payload.drafts[noteKey];
+      } else {
+        payload.drafts[noteKey] = {
+          content,
+          updatedAt: new Date().toISOString(),
+        };
       }
-      notesPayload.notes[noteKey] = {
-        id: noteKey,
-        type: noteType,
-        title: noteTitle,
-        content,
-        updatedAt: new Date().toISOString(),
-      };
-      persistAllNotes(notesPayload);
+      persistAllNotes(payload);
+    }
+
+    function clearDraft(shouldPersist = true) {
+      const payload = ensurePayload();
+      if (payload.drafts[noteKey]) {
+        delete payload.drafts[noteKey];
+        if (shouldPersist) {
+          persistAllNotes(payload);
+        }
+      }
+      return payload;
     }
 
     /**
@@ -291,28 +439,88 @@ const noteKey = `${contentType}:${contentId}`;
     }
 
     /**
-     * @param {NoteEntry | null} note
+     * @param {NoteCollection} collection
      */
-    function updateMeta(note) {
-      if (!note || !note.content.trim()) {
-        setMeta("No saved note yet.");
+    function renderNoteList(collection) {
+      list.innerHTML = "";
+      if (!collection || collection.items.length === 0) {
+        const empty = document.createElement("li");
+        empty.className = "note-item";
+        const body = document.createElement("p");
+        body.className = "note-item__body";
+        body.textContent = "No saved notes yet.";
+        empty.appendChild(body);
+        list.appendChild(empty);
         return;
       }
-      const formatted = formatTimestamp(note.updatedAt);
-      setMeta(formatted ? `Saved ${formatted}` : "Saved locally.");
+
+      const fragment = document.createDocumentFragment();
+      collection.items
+        .slice()
+        .sort((a, b) => (a.savedAt < b.savedAt ? 1 : -1))
+        .forEach((item) => {
+          const li = document.createElement("li");
+          li.className = "note-item";
+
+          const header = document.createElement("div");
+          header.className = "note-item__header";
+
+          const timestamp = document.createElement("time");
+          timestamp.className = "note-item__timestamp";
+          timestamp.dateTime = item.savedAt;
+          const formatted = formatTimestamp(item.savedAt);
+          timestamp.textContent = formatted
+            ? `Saved ${formatted}`
+            : "Saved locally";
+
+          header.appendChild(timestamp);
+
+          const body = document.createElement("p");
+          body.className = "note-item__body";
+          body.textContent = item.content;
+
+          li.appendChild(header);
+          li.appendChild(body);
+
+          fragment.appendChild(li);
+        });
+
+      list.appendChild(fragment);
+    }
+
+    /**
+     * @param {NoteCollection} collection
+     */
+    function updateMeta(collection) {
+      if (!collection || collection.items.length === 0) {
+        setMeta("No saved notes yet.");
+        return;
+      }
+      const formatted = formatTimestamp(collection.updatedAt);
+      const count = collection.items.length;
+      setMeta(
+        formatted
+          ? `${count} saved ${count === 1 ? "note" : "notes"}. Latest ${formatted}.`
+          : `${count} saved ${count === 1 ? "note" : "notes"}.`
+      );
     }
 
     function refreshFromStorage() {
-      const note = loadCurrentNote();
-      textarea.value = note.content;
-      updatePreview(note.content);
-      dirty = false;
-      updateMeta(note);
+      const collection = loadCollection();
+      const draft = loadDraft();
+      const draftContent = draft?.content ?? "";
+      textarea.value = draftContent;
+      updatePreview(draftContent);
+      dirty = Boolean(draftContent.trim());
+      renderNoteList(collection);
+      updateMeta(collection);
       setStatus(
         storageReady
-          ? note.content
-            ? "Note loaded from local storage."
-            : "Start writing to create a local note, then save."
+          ? draftContent
+            ? "Draft restored. Save to add it to your notes or clear it."
+            : collection.items.length
+            ? "Notes loaded from local storage."
+            : "Start a note and it'll stay here until you save."
           : "Local storage is unavailable; notes stay on this page only."
       );
 
@@ -321,6 +529,7 @@ const noteKey = `${contentType}:${contentId}`;
         textarea.classList.add("note-field--readonly");
         exportButton.setAttribute("disabled", "true");
         saveButton.setAttribute("disabled", "true");
+        clearButton.setAttribute("disabled", "true");
       }
     }
 
@@ -331,8 +540,13 @@ const noteKey = `${contentType}:${contentId}`;
         setStatus("Storage unavailable; notes won't persist.");
         return;
       }
-      dirty = true;
-      setStatus("Unsaved changes. Remember to save.");
+      dirty = Boolean(value.trim());
+      saveDraft(value);
+      setStatus(
+        value.trim()
+          ? "Draft saved locally. Click save to add it to your notes."
+          : "Draft cleared."
+      );
     });
 
     saveButton.addEventListener("click", () => {
@@ -340,18 +554,40 @@ const noteKey = `${contentType}:${contentId}`;
         setStatus("Cannot save: storage unavailable.");
         return;
       }
-      if (!dirty) {
-        setStatus("Nothing new to save.");
+      const value = textarea.value.trim();
+      if (!value) {
+        setStatus("Write something before saving.");
         return;
       }
-      const value = textarea.value;
-      saveCurrentNote(value);
-      const note = loadCurrentNote();
+      const payload = ensurePayload();
+      const collection = loadCollection();
+      const savedAt = new Date().toISOString();
+      const entry = {
+        id: `${noteKey}:${savedAt}`,
+        content: value,
+        savedAt,
+      };
+      collection.items.unshift(entry);
+      collection.updatedAt = savedAt;
+      payload.notes[noteKey] = collection;
+      clearDraft(false);
+      textarea.value = "";
+      updatePreview("");
       dirty = false;
-      updateMeta(note);
-      setStatus(
-        value.trim().length ? "Note saved locally." : "Cleared note."
-      );
+      renderNoteList(collection);
+      updateMeta(collection);
+      persistAllNotes(payload);
+      setStatus("Note saved locally.");
+    });
+
+    clearButton.addEventListener("click", () => {
+      textarea.value = "";
+      updatePreview("");
+      dirty = false;
+      if (storageReady) {
+        clearDraft();
+      }
+      setStatus("Draft cleared.");
     });
 
     exportButton.addEventListener("click", () => {
@@ -396,8 +632,21 @@ const noteKey = `${contentType}:${contentId}`;
   /**
    * @typedef {Object} NoteEntry
    * @property {string} id
+   * @property {string} content
+   * @property {string} savedAt
+   */
+
+  /**
+   * @typedef {Object} NoteCollection
+   * @property {string} id
    * @property {string} type
    * @property {string} title
+   * @property {NoteEntry[]} items
+   * @property {string} updatedAt
+   */
+
+  /**
+   * @typedef {Object} DraftEntry
    * @property {string} content
    * @property {string} updatedAt
    */
@@ -405,6 +654,22 @@ const noteKey = `${contentType}:${contentId}`;
   /**
    * @typedef {Object} NotesPayload
    * @property {number} version
-   * @property {Record<string, NoteEntry>} notes
+   * @property {Record<string, NoteCollection>} notes
+   * @property {Record<string, DraftEntry>} drafts
+   */
+
+  /**
+   * @typedef {Object} NotesPayloadLegacy
+   * @property {number} version
+   * @property {Record<string, NoteLegacyEntry>} notes
+   */
+
+  /**
+   * @typedef {Object} NoteLegacyEntry
+   * @property {string} id
+   * @property {string} type
+   * @property {string} title
+   * @property {string} content
+   * @property {string} updatedAt
    */
 </script>

--- a/src/components/NotesPanel.astro
+++ b/src/components/NotesPanel.astro
@@ -126,21 +126,27 @@ const noteKey = `${contentType}:${contentId}`;
     }
   })();
 
-  const panels = Array.from(
-    document.querySelectorAll<HTMLElement>("[data-note-root]")
-  );
+  const panels = Array.from(document.querySelectorAll("[data-note-root]"));
 
   panels.forEach((panel) => {
-    const textarea = panel.querySelector<HTMLTextAreaElement>("textarea");
-    const preview = panel.querySelector<HTMLDivElement>("[data-note-preview]");
-    const status = panel.querySelector<HTMLSpanElement>(".note-status");
-    const saveButton = panel.querySelector<HTMLButtonElement>(
-      "[data-note-save]"
+    const textarea = /** @type {HTMLTextAreaElement | null} */ (
+      panel.querySelector("textarea")
     );
-    const exportButton = panel.querySelector<HTMLButtonElement>(
-      "[data-note-export]"
+    const preview = /** @type {HTMLDivElement | null} */ (
+      panel.querySelector("[data-note-preview]")
     );
-    const meta = panel.querySelector<HTMLParagraphElement>("[data-note-meta]");
+    const status = /** @type {HTMLSpanElement | null} */ (
+      panel.querySelector(".note-status")
+    );
+    const saveButton = /** @type {HTMLButtonElement | null} */ (
+      panel.querySelector("[data-note-save]")
+    );
+    const exportButton = /** @type {HTMLButtonElement | null} */ (
+      panel.querySelector("[data-note-export]")
+    );
+    const meta = /** @type {HTMLParagraphElement | null} */ (
+      panel.querySelector("[data-note-meta]")
+    );
     if (!textarea || !preview || !status || !exportButton || !saveButton || !meta) {
       return;
     }
@@ -150,14 +156,21 @@ const noteKey = `${contentType}:${contentId}`;
     const noteType = panel.dataset.noteType ?? "content";
 
     let storageReady = storageSupported;
-    let notesPayload: NotesPayload | null = null;
+    /** @type {NotesPayload | null} */
+    let notesPayload = null;
     let dirty = false;
 
-    function emptyNotesPayload(): NotesPayload {
+    /**
+     * @returns {NotesPayload}
+     */
+    function emptyNotesPayload() {
       return { version: STORAGE_VERSION, notes: {} };
     }
 
-    function loadAllNotes(): NotesPayload {
+    /**
+     * @returns {NotesPayload}
+     */
+    function loadAllNotes() {
       if (!storageReady) return emptyNotesPayload();
       try {
         const raw = localStorage.getItem(STORAGE_NAMESPACE);
@@ -173,7 +186,7 @@ const noteKey = `${contentType}:${contentId}`;
         ) {
           return emptyNotesPayload();
         }
-        return parsed as NotesPayload;
+        return /** @type {NotesPayload} */ (parsed);
       } catch (error) {
         console.warn("Notes storage unavailable", error);
         storageReady = false;
@@ -181,7 +194,10 @@ const noteKey = `${contentType}:${contentId}`;
       }
     }
 
-    function persistAllNotes(payload: NotesPayload) {
+    /**
+     * @param {NotesPayload} payload
+     */
+    function persistAllNotes(payload) {
       if (!storageReady) return;
       try {
         localStorage.setItem(STORAGE_NAMESPACE, JSON.stringify(payload));
@@ -194,7 +210,10 @@ const noteKey = `${contentType}:${contentId}`;
       }
     }
 
-    function loadCurrentNote(): NoteEntry {
+    /**
+     * @returns {NoteEntry}
+     */
+    function loadCurrentNote() {
       if (!notesPayload) {
         notesPayload = loadAllNotes();
       }
@@ -209,7 +228,10 @@ const noteKey = `${contentType}:${contentId}`;
       };
     }
 
-    function saveCurrentNote(content: string) {
+    /**
+     * @param {string} content
+     */
+    function saveCurrentNote(content) {
       if (!notesPayload) {
         notesPayload = loadAllNotes();
       }
@@ -223,26 +245,41 @@ const noteKey = `${contentType}:${contentId}`;
       persistAllNotes(notesPayload);
     }
 
-    function setStatus(message: string) {
+    /**
+     * @param {string} message
+     */
+    function setStatus(message) {
       status.textContent = message;
     }
 
-    function setMeta(message: string) {
+    /**
+     * @param {string} message
+     */
+    function setMeta(message) {
       meta.textContent = message;
     }
 
-    function sanitizeForPreview(value: string) {
+    /**
+     * @param {string} value
+     */
+    function sanitizeForPreview(value) {
       const temp = document.createElement("div");
       temp.textContent = value;
       return temp.innerHTML;
     }
 
-    function updatePreview(value: string) {
+    /**
+     * @param {string} value
+     */
+    function updatePreview(value) {
       const sanitized = sanitizeForPreview(value);
       preview.innerHTML = sanitized;
     }
 
-    function formatTimestamp(iso: string) {
+    /**
+     * @param {string} iso
+     */
+    function formatTimestamp(iso) {
       const date = new Date(iso);
       if (Number.isNaN(date.getTime())) {
         return "";
@@ -253,7 +290,10 @@ const noteKey = `${contentType}:${contentId}`;
       });
     }
 
-    function updateMeta(note: NoteEntry | null) {
+    /**
+     * @param {NoteEntry | null} note
+     */
+    function updateMeta(note) {
       if (!note || !note.content.trim()) {
         setMeta("No saved note yet.");
         return;
@@ -336,18 +376,35 @@ const noteKey = `${contentType}:${contentId}`;
     });
 
     refreshFromStorage();
+
+    window.addEventListener("pageshow", () => {
+      if (storageReady) {
+        notesPayload = null;
+        refreshFromStorage();
+      }
+    });
+
+    window.addEventListener("storage", (event) => {
+      if (event.key === STORAGE_NAMESPACE) {
+        notesPayload = null;
+        refreshFromStorage();
+        setStatus("Note updated from another tab.");
+      }
+    });
   });
 
-  interface NoteEntry {
-    id: string;
-    type: string;
-    title: string;
-    content: string;
-    updatedAt: string;
-  }
+  /**
+   * @typedef {Object} NoteEntry
+   * @property {string} id
+   * @property {string} type
+   * @property {string} title
+   * @property {string} content
+   * @property {string} updatedAt
+   */
 
-  interface NotesPayload {
-    version: number;
-    notes: Record<string, NoteEntry>;
-  }
+  /**
+   * @typedef {Object} NotesPayload
+   * @property {number} version
+   * @property {Record<string, NoteEntry>} notes
+   */
 </script>

--- a/src/components/NotesPanel.astro
+++ b/src/components/NotesPanel.astro
@@ -1,0 +1,353 @@
+---
+interface Props {
+  contentId: string;
+  contentType: string;
+  contentTitle: string;
+}
+const { contentId, contentType, contentTitle } = Astro.props as Props;
+const noteKey = `${contentType}:${contentId}`;
+---
+
+<section
+  class="notes-panel"
+  data-note-root
+  data-note-key={noteKey}
+  data-note-title={contentTitle}
+  data-note-type={contentType}
+>
+  <h2>Your notes</h2>
+  <p class="note-helper">
+    Notes live on your device first. We'll keep them ready for optional sync later.
+  </p>
+  <label class="note-field">
+    <span class="note-field__label">Markdown-friendly note</span>
+    <textarea
+      rows="8"
+      placeholder="Capture how you adapt this content to your troupe..."
+      aria-describedby={`note-status-${noteKey}`}
+    ></textarea>
+  </label>
+  <p class="note-meta" data-note-meta></p>
+  <div class="note-toolbar">
+    <button type="button" class="primary" data-note-save>
+      Save note
+    </button>
+    <button type="button" class="secondary" data-note-export>
+      Export all notes
+    </button>
+    <span
+      id={`note-status-${noteKey}`}
+      role="status"
+      class="note-status"
+      aria-live="polite"
+    ></span>
+  </div>
+  <details class="note-preview">
+    <summary>Preview</summary>
+    <div data-note-preview></div>
+  </details>
+</section>
+
+<style>
+  .notes-panel {
+    margin-top: 3rem;
+    border-top: 1px solid var(--pico-muted-border-color, hsla(0, 0%, 100%, 0.1));
+    padding-top: 2rem;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .note-helper {
+    margin: 0;
+    color: var(--pico-muted-color);
+    font-size: 0.95rem;
+  }
+
+  .note-field {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .note-field textarea {
+    width: 100%;
+    resize: vertical;
+  }
+
+  .note-field textarea.note-field--readonly {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .note-meta {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--pico-muted-color);
+  }
+
+  .note-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+  }
+
+  .note-status {
+    min-height: 1.5rem;
+    font-size: 0.9rem;
+    color: var(--pico-muted-color);
+  }
+
+  .note-preview summary {
+    cursor: pointer;
+  }
+
+  .note-preview div {
+    padding: 0.5rem 0;
+    white-space: pre-wrap;
+    font-family: var(--pico-font-family-monospace, ui-monospace, SFMono-Regular, SFMono, "Roboto Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+  }
+</style>
+
+<script type="module" lang="ts">
+  const STORAGE_NAMESPACE = "improv-toolbox:notes";
+  const STORAGE_VERSION = 1;
+  const storageSupported = (() => {
+    if (typeof window === "undefined" || !("localStorage" in window)) {
+      return false;
+    }
+    try {
+      const probeKey = "improv-toolbox:notes-probe";
+      localStorage.setItem(probeKey, "ok");
+      localStorage.removeItem(probeKey);
+      return true;
+    } catch (error) {
+      console.warn("Local storage is not available for notes", error);
+      return false;
+    }
+  })();
+
+  const panels = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-note-root]")
+  );
+
+  panels.forEach((panel) => {
+    const textarea = panel.querySelector<HTMLTextAreaElement>("textarea");
+    const preview = panel.querySelector<HTMLDivElement>("[data-note-preview]");
+    const status = panel.querySelector<HTMLSpanElement>(".note-status");
+    const saveButton = panel.querySelector<HTMLButtonElement>(
+      "[data-note-save]"
+    );
+    const exportButton = panel.querySelector<HTMLButtonElement>(
+      "[data-note-export]"
+    );
+    const meta = panel.querySelector<HTMLParagraphElement>("[data-note-meta]");
+    if (!textarea || !preview || !status || !exportButton || !saveButton || !meta) {
+      return;
+    }
+
+    const noteKey = panel.dataset.noteKey ?? "";
+    const noteTitle = panel.dataset.noteTitle ?? "";
+    const noteType = panel.dataset.noteType ?? "content";
+
+    let storageReady = storageSupported;
+    let notesPayload: NotesPayload | null = null;
+    let dirty = false;
+
+    function emptyNotesPayload(): NotesPayload {
+      return { version: STORAGE_VERSION, notes: {} };
+    }
+
+    function loadAllNotes(): NotesPayload {
+      if (!storageReady) return emptyNotesPayload();
+      try {
+        const raw = localStorage.getItem(STORAGE_NAMESPACE);
+        if (!raw) {
+          return emptyNotesPayload();
+        }
+        const parsed = JSON.parse(raw);
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          typeof parsed.version !== "number" ||
+          typeof parsed.notes !== "object"
+        ) {
+          return emptyNotesPayload();
+        }
+        return parsed as NotesPayload;
+      } catch (error) {
+        console.warn("Notes storage unavailable", error);
+        storageReady = false;
+        return emptyNotesPayload();
+      }
+    }
+
+    function persistAllNotes(payload: NotesPayload) {
+      if (!storageReady) return;
+      try {
+        localStorage.setItem(STORAGE_NAMESPACE, JSON.stringify(payload));
+      } catch (error) {
+        console.warn("Failed to persist notes", error);
+        storageReady = false;
+        setStatus("Saving failed: storage is unavailable.");
+        textarea.setAttribute("readonly", "true");
+        textarea.classList.add("note-field--readonly");
+      }
+    }
+
+    function loadCurrentNote(): NoteEntry {
+      if (!notesPayload) {
+        notesPayload = loadAllNotes();
+      }
+      const existing = notesPayload.notes[noteKey];
+      if (existing) return existing;
+      return {
+        id: noteKey,
+        type: noteType,
+        title: noteTitle,
+        content: "",
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    function saveCurrentNote(content: string) {
+      if (!notesPayload) {
+        notesPayload = loadAllNotes();
+      }
+      notesPayload.notes[noteKey] = {
+        id: noteKey,
+        type: noteType,
+        title: noteTitle,
+        content,
+        updatedAt: new Date().toISOString(),
+      };
+      persistAllNotes(notesPayload);
+    }
+
+    function setStatus(message: string) {
+      status.textContent = message;
+    }
+
+    function setMeta(message: string) {
+      meta.textContent = message;
+    }
+
+    function sanitizeForPreview(value: string) {
+      const temp = document.createElement("div");
+      temp.textContent = value;
+      return temp.innerHTML;
+    }
+
+    function updatePreview(value: string) {
+      const sanitized = sanitizeForPreview(value);
+      preview.innerHTML = sanitized;
+    }
+
+    function formatTimestamp(iso: string) {
+      const date = new Date(iso);
+      if (Number.isNaN(date.getTime())) {
+        return "";
+      }
+      return date.toLocaleString(undefined, {
+        dateStyle: "short",
+        timeStyle: "short",
+      });
+    }
+
+    function updateMeta(note: NoteEntry | null) {
+      if (!note || !note.content.trim()) {
+        setMeta("No saved note yet.");
+        return;
+      }
+      const formatted = formatTimestamp(note.updatedAt);
+      setMeta(formatted ? `Saved ${formatted}` : "Saved locally.");
+    }
+
+    function refreshFromStorage() {
+      const note = loadCurrentNote();
+      textarea.value = note.content;
+      updatePreview(note.content);
+      dirty = false;
+      updateMeta(note);
+      setStatus(
+        storageReady
+          ? note.content
+            ? "Note loaded from local storage."
+            : "Start writing to create a local note, then save."
+          : "Local storage is unavailable; notes stay on this page only."
+      );
+
+      if (!storageReady) {
+        textarea.setAttribute("readonly", "true");
+        textarea.classList.add("note-field--readonly");
+        exportButton.setAttribute("disabled", "true");
+        saveButton.setAttribute("disabled", "true");
+      }
+    }
+
+    textarea.addEventListener("input", () => {
+      const value = textarea.value;
+      updatePreview(value);
+      if (!storageReady) {
+        setStatus("Storage unavailable; notes won't persist.");
+        return;
+      }
+      dirty = true;
+      setStatus("Unsaved changes. Remember to save.");
+    });
+
+    saveButton.addEventListener("click", () => {
+      if (!storageReady) {
+        setStatus("Cannot save: storage unavailable.");
+        return;
+      }
+      if (!dirty) {
+        setStatus("Nothing new to save.");
+        return;
+      }
+      const value = textarea.value;
+      saveCurrentNote(value);
+      const note = loadCurrentNote();
+      dirty = false;
+      updateMeta(note);
+      setStatus(
+        value.trim().length ? "Note saved locally." : "Cleared note."
+      );
+    });
+
+    exportButton.addEventListener("click", () => {
+      if (!storageReady) {
+        setStatus("Nothing to export yet.");
+        return;
+      }
+      const payload = notesPayload ?? loadAllNotes();
+      const blob = new Blob([JSON.stringify(payload, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      const timestamp = new Date().toISOString().replace(/[:]/g, "-");
+      anchor.href = url;
+      anchor.download = `improv-toolbox-notes-${timestamp}.json`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      window.setTimeout(() => URL.revokeObjectURL(url), 2000);
+      setStatus("Exported notes to a JSON file.");
+    });
+
+    refreshFromStorage();
+  });
+
+  interface NoteEntry {
+    id: string;
+    type: string;
+    title: string;
+    content: string;
+    updatedAt: string;
+  }
+
+  interface NotesPayload {
+    version: number;
+    notes: Record<string, NoteEntry>;
+  }
+</script>

--- a/src/pages/exercises/[slug].astro
+++ b/src/pages/exercises/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
+import NotesPanel from "../../components/NotesPanel.astro";
 import { getCollection, getEntry } from "astro:content";
 export async function getStaticPaths() {
   const exercises = await getCollection("exercises");
@@ -28,4 +29,9 @@ const exercise = await getEntry("exercises", slug as string);
   <article>
     <p>{exercise?.data.description}</p>
   </article>
+  <NotesPanel
+    contentId={exercise?.slug ?? ""}
+    contentType="exercise"
+    contentTitle={exercise?.data.name ?? "Exercise"}
+  />
 </BaseLayout>

--- a/src/pages/forms/[slug].astro
+++ b/src/pages/forms/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
+import NotesPanel from "../../components/NotesPanel.astro";
 import { getCollection, getEntry } from "astro:content";
 export async function getStaticPaths() {
   const forms = await getCollection("forms");
@@ -20,4 +21,9 @@ const form = await getEntry("forms", slug);
     <p>{form?.data.description}</p>
   </article>
   <p><a href={form?.data.source} target="_blank">Source</a></p>
+  <NotesPanel
+    contentId={form?.slug ?? ""}
+    contentType="form"
+    contentTitle={form?.data.name ?? "Form"}
+  />
 </BaseLayout>

--- a/src/pages/warmups/[slug].astro
+++ b/src/pages/warmups/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
+import NotesPanel from "../../components/NotesPanel.astro";
 import { getCollection, getEntry } from "astro:content";
 export async function getStaticPaths() {
   const warmups = await getCollection("warmups");
@@ -26,4 +27,9 @@ const warmup = await getEntry("warmups", slug);
   <article>
     <p>{warmup?.data.description}</p>
   </article>
+  <NotesPanel
+    contentId={warmup?.slug ?? ""}
+    contentType="warmup"
+    contentTitle={warmup?.data.name ?? "Warmup"}
+  />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add a reusable notes panel component that stores per-content notes locally with sanitised preview and export tooling
- embed the notes panel on exercise, warmup, and form detail pages so every content item can capture personal notes
- add explicit save controls with timestamp metadata so saved notes surface clearly alongside content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91a6433b4832a9a4fa8f0034f0001