### PR TITLE
Sort list views alphabetically

### DIFF
--- a/src/pages/exercises/index.astro
+++ b/src/pages/exercises/index.astro
@@ -3,14 +3,20 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import FilterDrawer from "../../components/FilterDrawer.astro";
 import { getCollection } from "astro:content";
-const exercises = await getCollection("exercises");
-const names = Array.from(new Set(exercises.map((e) => e.data.name)));
+const exercises = (await getCollection("exercises")).sort((a, b) =>
+  a.data.name.localeCompare(b.data.name)
+);
+const names = Array.from(new Set(exercises.map((e) => e.data.name))).sort(
+  (a, b) => a.localeCompare(b)
+);
 const focuses = Array.from(
   new Set(exercises.map((e) => e.data.focus).filter(Boolean))
-);
+).sort((a, b) => a.localeCompare(b));
 const minPeople = Array.from(
-  new Set(exercises.map((e) => e.data.minimumPeople).filter(Boolean))
-);
+  new Set(exercises.map((e) => e.data.minimumPeople).filter((value) =>
+    value != null
+  ))
+).sort((a, b) => a - b);
 ---
 
 <BaseLayout>

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -3,11 +3,15 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import FilterDrawer from "../../components/FilterDrawer.astro";
 import { getCollection } from "astro:content";
-const forms = await getCollection("forms");
-const names = Array.from(new Set(forms.map((f) => f.data.name)));
+const forms = (await getCollection("forms")).sort((a, b) =>
+  a.data.name.localeCompare(b.data.name)
+);
+const names = Array.from(new Set(forms.map((f) => f.data.name))).sort((a, b) =>
+  a.localeCompare(b)
+);
 const types = Array.from(
   new Set(forms.map((f) => f.data.type).filter(Boolean))
-);
+).sort((a, b) => a.localeCompare(b));
 ---
 
 <BaseLayout>

--- a/src/pages/warmups/index.astro
+++ b/src/pages/warmups/index.astro
@@ -3,14 +3,20 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import FilterDrawer from "../../components/FilterDrawer.astro";
 import { getCollection } from "astro:content";
-const warmups = await getCollection("warmups");
-const names = Array.from(new Set(warmups.map((w) => w.data.name)));
+const warmups = (await getCollection("warmups")).sort((a, b) =>
+  a.data.name.localeCompare(b.data.name)
+);
+const names = Array.from(new Set(warmups.map((w) => w.data.name))).sort(
+  (a, b) => a.localeCompare(b)
+);
 const focuses = Array.from(
   new Set(warmups.map((w) => w.data.focus).filter(Boolean))
-);
+).sort((a, b) => a.localeCompare(b));
 const minPeople = Array.from(
-  new Set(warmups.map((w) => w.data.minimumPeople).filter(Boolean))
-);
+  new Set(warmups.map((w) => w.data.minimumPeople).filter((value) =>
+    value != null
+  ))
+).sort((a, b) => a - b);
 ---
 
 <BaseLayout>


### PR DESCRIPTION
## Summary
- order the exercises, forms, and warmups collections alphabetically by name
- sort filter dropdown options to match the listing order for each page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d992fa3024832a98a53dce56fcaca8