### PR TITLE
Move drawer trigger into header for mobile navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -269,6 +269,12 @@ button,
   min-width: 0;
 }
 
+.app-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .app-logo {
   font-size: clamp(1.1rem, 4vw, 1.4rem);
   font-weight: 700;
@@ -296,6 +302,12 @@ button,
   font-size: 0.85rem;
   font-weight: 600;
   text-transform: uppercase;
+}
+
+@media (max-width: 779px) {
+  .tab-nav {
+    display: none;
+  }
 }
 
 .tab-nav {

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -117,20 +117,17 @@ const icons = {
     color: rgba(255, 220, 229, 0.8);
   }
   .drawer-toggle {
-    position: fixed;
-    right: clamp(1rem, 4vw, 2rem);
-    bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
-    width: 3.25rem;
-    height: 3.25rem;
-    border-radius: var(--radius-lg);
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    margin-right: 0.5rem;
+    border-radius: var(--radius-lg);
     background: radial-gradient(circle at 30% 30%, #ff758a, #ff2f55 70%);
     color: #0c0205;
     border: none;
-    box-shadow: 0 22px 38px rgba(255, 63, 94, 0.35);
-    z-index: 1100;
+    box-shadow: 0 12px 26px rgba(255, 63, 94, 0.3);
     cursor: pointer;
     transition: transform 0.25s ease, box-shadow 0.25s ease;
   }
@@ -145,12 +142,16 @@ const icons = {
   .drawer-toggle.open svg {
     transform: rotate(45deg);
   }
-  .drawer.open ~ .drawer-toggle {
-    display: none;
-  }
   @media (min-width: 768px) {
     .drawer {
       width: 360px;
+    }
+  }
+  @media (min-width: 780px) {
+    .drawer,
+    .drawer-backdrop,
+    .drawer-toggle {
+      display: none;
     }
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -46,16 +46,18 @@ const isActive = (href: string) =>
     <meta name="mobile-web-app-capable" content="yes" />
   </head>
   <body>
-    <Drawer title="Navigate" links={navLinks}>
-      <p class="app-tagline">Plan, teach, and play on the fly.</p>
-    </Drawer>
     <header class="app-bar" role="banner">
       <div class="app-bar__inner">
         <div class="app-bar__brand">
           <a class="app-logo" href="/">Improv Toolbox</a>
           <span class="app-tagline">Warmups · Forms · Tools</span>
         </div>
-        <a class="app-cta" href="/tools/timer">Quick timer</a>
+        <div class="app-bar__actions">
+          <Drawer title="Navigate" links={navLinks}>
+            <p class="app-tagline">Plan, teach, and play on the fly.</p>
+          </Drawer>
+          <a class="app-cta" href="/tools/timer">Quick timer</a>
+        </div>
       </div>
       <nav class="tab-nav" aria-label="Primary navigation">
         {


### PR DESCRIPTION
## Summary
- relocate the drawer component into the app header and wrap new header actions container
- restyle the drawer toggle for inline placement and hide drawer UI above the desktop breakpoint
- add a mobile breakpoint that hides the tab navigation when the drawer is primary

## Testing
- npm test *(fails: existing content expectations in tests/site.test.mjs do not match current markup)*

------
https://chatgpt.com/codex/tasks/task_e_68d9accf7bb4832abcd563f667547631