### PR TITLE
Add persistent mobile navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -322,6 +322,53 @@ button,
   scrollbar-width: thin;
 }
 
+.bottom-nav {
+  display: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 950;
+  padding: 0.4rem clamp(1rem, 6vw, 2.25rem)
+    calc(0.45rem + env(safe-area-inset-bottom, 0px));
+  background: color-mix(in srgb, var(--surface-color) 92%, transparent);
+  backdrop-filter: blur(16px);
+  border-top: 1px solid var(--color-border-subtle);
+  gap: 0.5rem;
+}
+
+.bottom-nav a {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.35rem;
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted-strong);
+  background: color-mix(in srgb, var(--surface-raised) 78%, transparent);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bottom-nav a[aria-current="page"] {
+  background: linear-gradient(135deg, var(--color-accent) 0%, #ff6b82 100%);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #12030b;
+  box-shadow: 0 14px 30px rgba(255, 71, 97, 0.35);
+}
+
+.bottom-nav a:hover,
+.bottom-nav a:focus-visible {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--color-accent) 18%, var(--surface-raised) 82%);
+  color: var(--color-heading);
+  box-shadow: 0 12px 28px rgba(255, 71, 97, 0.28);
+}
+
 .tab-nav::-webkit-scrollbar {
   height: 4px;
 }
@@ -368,6 +415,16 @@ button,
   padding: clamp(1.25rem, 5vw, 3rem) clamp(1rem, 4vw, 3rem) calc(3.5rem + var(--safe-bottom));
   display: grid;
   gap: clamp(2rem, 5vw, 3rem);
+}
+
+@media (max-width: 779px) {
+  .bottom-nav {
+    display: flex;
+  }
+
+  .page-shell {
+    padding-bottom: calc(6rem + var(--safe-bottom));
+  }
 }
 
 .page-section {

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -122,7 +122,6 @@ const icons = {
     justify-content: center;
     width: 2.75rem;
     height: 2.75rem;
-    margin-right: 0.5rem;
     border-radius: var(--radius-lg);
     background: radial-gradient(circle at 30% 30%, #ff758a, #ff2f55 70%);
     color: #0c0205;
@@ -141,6 +140,15 @@ const icons = {
   }
   .drawer-toggle.open svg {
     transform: rotate(45deg);
+  }
+  @media (max-width: 779px) {
+    .drawer-toggle {
+      position: fixed;
+      left: clamp(1rem, 6vw, 2.25rem);
+      bottom: calc(4.75rem + env(safe-area-inset-bottom, 0px));
+      margin: 0;
+      z-index: 952;
+    }
   }
   @media (min-width: 768px) {
     .drawer {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -75,6 +75,18 @@ const isActive = (href: string) =>
     <main class="page-shell stack">
       <slot />
     </main>
+    <nav class="bottom-nav" aria-label="Primary navigation">
+      {
+        navLinks.map((link) => (
+          <a
+            href={link.href}
+            aria-current={isActive(link.href) ? "page" : undefined}
+          >
+            {link.label}
+          </a>
+        ))
+      }
+    </nav>
     <footer class="site-footer">
       <small>© {currentYear} Improv Toolbox Collective</small>
     </footer>


### PR DESCRIPTION
## Summary
- add a bottom navigation bar on mobile so primary destinations stay accessible while scrolling
- float the drawer toggle above the safe area on handheld breakpoints for a persistent menu affordance
- adjust mobile spacing to accommodate the new controls without overlapping content

## Testing
- npm test *(fails: existing content assertions in tests/site.test.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b3151f54832aa05fb948a193076d