### PR TITLE
Add scroll-aware mobile bottom navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -349,6 +349,13 @@ button,
   border-top: 1px solid var(--color-border-subtle);
   gap: 0.5rem;
   align-items: center;
+  transition: transform 0.32s ease, opacity 0.24s ease;
+}
+
+.bottom-nav--hidden {
+  transform: translateY(calc(100% + env(safe-area-inset-bottom, 0px)));
+  opacity: 0;
+  pointer-events: none;
 }
 
 .bottom-nav__item {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -87,9 +87,10 @@ const isActive = (href: string) =>
           navLinks.map((link) => (
             <a
               href={link.href}
+              data-drawer-link
               aria-current={isActive(link.href) ? "page" : undefined}
             >
-              {link.label}
+              <span>{link.label}</span>
             </a>
           ))
         }
@@ -119,6 +120,44 @@ const isActive = (href: string) =>
     <footer class="site-footer">
       <small>© {currentYear} Improv Toolbox Collective</small>
     </footer>
+
+    <script>
+      (() => {
+        const bottomNav = document.querySelector(".bottom-nav");
+        if (!bottomNav) return;
+
+        let lastScrollY = window.scrollY || 0;
+        let ticking = false;
+        const DELTA_HIDE = 6;
+        const TOP_OFFSET = 48;
+
+        const updateVisibility = () => {
+          const currentScrollY = window.scrollY || 0;
+          const scrollDelta = currentScrollY - lastScrollY;
+          const scrollingDown = scrollDelta > DELTA_HIDE;
+          const scrollingUp = scrollDelta < -DELTA_HIDE;
+          const nearTop = currentScrollY <= TOP_OFFSET;
+
+          if (nearTop || scrollingUp) {
+            bottomNav.classList.remove("bottom-nav--hidden");
+          } else if (scrollingDown) {
+            bottomNav.classList.add("bottom-nav--hidden");
+          }
+
+          lastScrollY = currentScrollY;
+          ticking = false;
+        };
+
+        const requestTick = () => {
+          if (!ticking) {
+            window.requestAnimationFrame(updateVisibility);
+            ticking = true;
+          }
+        };
+
+        window.addEventListener("scroll", requestTick, { passive: true });
+      })();
+    </script>
 
     <script>
       if ("serviceWorker" in navigator) {


### PR DESCRIPTION
## Summary
- add a hide state and transitions for the mobile bottom navigation bar
- add a scroll listener to collapse the bottom navigation when scrolling down and reveal it near the top or when scrolling up
- wrap primary tab links with spans flagged for drawer navigation to preserve existing markup expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da64661ce4832a9bd2324374265605