### PR TITLE
Add favorites support to collection listings

### DIFF
--- a/src/components/FilterDrawer.astro
+++ b/src/components/FilterDrawer.astro
@@ -53,6 +53,18 @@ const { fields = [], slot } = Astro.props;
     font-weight: 600;
     font-size: 0.95rem;
   }
+  .filter-form__checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+  .filter-form__checkbox input[type="checkbox"] {
+    width: 1.1rem;
+    height: 1.1rem;
+    accent-color: var(--color-accent, #ff2f55);
+  }
   .filter-drawer-toggle {
     all: unset;
   }
@@ -80,21 +92,32 @@ const { fields = [], slot } = Astro.props;
   <h2>Refine</h2>
   <form class="filter-form">
     {
-      fields.map((field) => (
-        <label>
-          {field.label}
-          {field.type === "select" ? (
-            <select name={field.name}>
-              <option value="">All</option>
-              {field.options?.map((opt) => (
-                <option value={opt}>{opt}</option>
-              ))}
-            </select>
-          ) : (
-            <input type={field.type} name={field.name} />
-          )}
-        </label>
-      ))
+      fields.map((field) => {
+        const inputId = `filter-${field.name}`;
+        if (field.type === "checkbox") {
+          return (
+            <label class="filter-form__checkbox">
+              <input id={inputId} type="checkbox" name={field.name} />
+              <span>{field.label}</span>
+            </label>
+          );
+        }
+        return (
+          <label for={inputId}>
+            {field.label}
+            {field.type === "select" ? (
+              <select id={inputId} name={field.name}>
+                <option value="">All</option>
+                {field.options?.map((opt) => (
+                  <option value={opt}>{opt}</option>
+                ))}
+              </select>
+            ) : (
+              <input id={inputId} type={field.type} name={field.name} />
+            )}
+          </label>
+        );
+      })
     }
   </form>
   <div>{slot}</div>

--- a/src/pages/exercises/index.astro
+++ b/src/pages/exercises/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import FilterDrawer from "../../components/FilterDrawer.astro";
+import FavoriteToggle from "../../components/FavoriteToggle.astro";
 import { getCollection } from "astro:content";
 const exercises = (await getCollection("exercises")).sort((a, b) =>
   a.data.name.localeCompare(b.data.name)
@@ -50,6 +51,7 @@ const minPeople = Array.from(
                   options: minPeople.map(String),
                 }
               : null,
+            { name: "favoritesOnly", label: "Favourites only", type: "checkbox" },
           ].filter(Boolean)}
         />
       </div>
@@ -66,10 +68,17 @@ const minPeople = Array.from(
                 ? String(exercise.data.minimumPeople)
                 : ""
             }
+            data-favorite="false"
           >
             <h2 class="resource-card__title">
               <a href={`/exercises/${exercise.slug}`}>{exercise.data.name}</a>
             </h2>
+            <FavoriteToggle
+              contentType="exercise"
+              slug={exercise.slug}
+              title={exercise.data.name}
+              description={exercise.data.shortDescription}
+            />
             <p class="resource-card__summary">{exercise.data.shortDescription}</p>
             <div class="meta-badges">
               {exercise.data.focus && <span class="meta-badge">Focus · {exercise.data.focus}</span>}
@@ -84,27 +93,87 @@ const minPeople = Array.from(
       }
     </ul>
   </section>
-  <script>
-    const form = document.querySelector(".filter-form");
+  <script type="module" lang="ts">
+    import {
+      loadFavorites,
+      subscribeToFavorites,
+    } from "../../utils/favorites";
+
+    const form = document.querySelector<HTMLFormElement>(".filter-form");
     const list = document.getElementById("exerciseList");
-    form &&
-      form.addEventListener("change", () => {
-        const nameInput = form.querySelector('[name="name"]');
-        const focusInput = form.querySelector('[name="focus"]');
-        const minPeopleInput = form.querySelector('[name="minimumPeople"]');
-        const name = nameInput ? nameInput.value : "";
-        const focus = focusInput ? focusInput.value : "";
-        const minPeople = minPeopleInput ? minPeopleInput.value : "";
-        Array.from(list?.children || []).forEach((li) => {
-          const el = li;
-          const matchesName = !name || el.dataset.name === name;
-          const matchesFocus = !focus || el.dataset.focus === focus;
-          const matchesMinPeople =
-            !minPeople || el.dataset.minimumPeople === minPeople;
-          el.style.display =
-            matchesName && matchesFocus && matchesMinPeople ? "" : "none";
-        });
+    const cards = list
+      ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
+      : [];
+
+    const applyFavorites = (items: Record<string, unknown>) => {
+      cards.forEach((card) => {
+        const toggleRoot = card.querySelector<HTMLElement>(
+          "[data-favorite-root]"
+        );
+        const key = toggleRoot?.dataset.favoriteKey ?? "";
+        const isFavorite = Boolean(key && items[key]);
+        card.dataset.favorite = String(isFavorite);
+        const button = toggleRoot?.querySelector<HTMLButtonElement>(
+          "[data-favorite-button]"
+        );
+        if (button) {
+          button.setAttribute("aria-pressed", String(isFavorite));
+        }
       });
+    };
+
+    const applyFilters = () => {
+      const name =
+        form?.querySelector<HTMLSelectElement>("[name=\"name\"]")?.value ??
+        "";
+      const focus =
+        form?.querySelector<HTMLSelectElement>("[name=\"focus\"]")?.value ??
+        "";
+      const minPeople =
+        form
+          ?.querySelector<HTMLSelectElement>("[name=\"minimumPeople\"]")
+          ?.value ?? "";
+      const favoritesOnly = Boolean(
+        form?.querySelector<HTMLInputElement>("[name=\"favoritesOnly\"]")
+          ?.checked
+      );
+
+      cards.forEach((card) => {
+        const matchesName = !name || card.dataset.name === name;
+        const matchesFocus = !focus || card.dataset.focus === focus;
+        const matchesMinPeople =
+          !minPeople || card.dataset.minimumPeople === minPeople;
+        const matchesFavorite =
+          !favoritesOnly || card.dataset.favorite === "true";
+        card.style.display =
+          matchesName &&
+          matchesFocus &&
+          matchesMinPeople &&
+          matchesFavorite
+            ? ""
+            : "none";
+      });
+    };
+
+    const payload = loadFavorites();
+    applyFavorites(payload.items);
+    applyFilters();
+
+    form?.addEventListener("change", applyFilters);
+
+    const unsubscribe = subscribeToFavorites((detail) => {
+      if (!detail || !detail.payload) return;
+      applyFavorites(detail.payload.items);
+      applyFilters();
+    });
+
+    window.addEventListener(
+      "astro:before-swap",
+      () => {
+        unsubscribe?.();
+      },
+      { once: true }
+    );
   </script>
   <style>
     .resource-card__title a {

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import FilterDrawer from "../../components/FilterDrawer.astro";
+import FavoriteToggle from "../../components/FavoriteToggle.astro";
 import { getCollection } from "astro:content";
 const forms = (await getCollection("forms")).sort((a, b) =>
   a.data.name.localeCompare(b.data.name)
@@ -32,6 +33,7 @@ const types = Array.from(
             types.length
               ? { name: "type", label: "Type", type: "select", options: types }
               : null,
+            { name: "favoritesOnly", label: "Favourites only", type: "checkbox" },
           ].filter(Boolean)}
         />
       </div>
@@ -43,10 +45,17 @@ const types = Array.from(
             class="resource-card"
             data-name={form.data.name}
             data-type={form.data.type ?? ""}
+            data-favorite="false"
           >
             <h2 class="resource-card__title">
               <a href={`/forms/${form.slug}`}>{form.data.name}</a>
             </h2>
+            <FavoriteToggle
+              contentType="form"
+              slug={form.slug}
+              title={form.data.name}
+              description={form.data.shortDescription}
+            />
             <p class="resource-card__summary">{form.data.shortDescription}</p>
             <div class="meta-badges">
               {form.data.type && <span class="meta-badge">Type · {form.data.type}</span>}
@@ -56,22 +65,76 @@ const types = Array.from(
       }
     </ul>
   </section>
-  <script>
-    const form = document.querySelector(".filter-form");
+  <script type="module" lang="ts">
+    import {
+      loadFavorites,
+      subscribeToFavorites,
+    } from "../../utils/favorites";
+
+    const form = document.querySelector<HTMLFormElement>(".filter-form");
     const list = document.getElementById("formList");
-    form &&
-      form.addEventListener("change", () => {
-        const nameInput = form.querySelector('[name="name"]');
-        const typeInput = form.querySelector('[name="type"]');
-        const name = nameInput ? nameInput.value : "";
-        const type = typeInput ? typeInput.value : "";
-        Array.from(list?.children || []).forEach((li) => {
-          const el = li;
-          const matchesName = !name || el.dataset.name === name;
-          const matchesType = !type || el.dataset.type === type;
-          el.style.display = matchesName && matchesType ? "" : "none";
-        });
+    const cards = list
+      ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
+      : [];
+
+    const applyFavorites = (items: Record<string, unknown>) => {
+      cards.forEach((card) => {
+        const toggleRoot = card.querySelector<HTMLElement>(
+          "[data-favorite-root]"
+        );
+        const key = toggleRoot?.dataset.favoriteKey ?? "";
+        const isFavorite = Boolean(key && items[key]);
+        card.dataset.favorite = String(isFavorite);
+        const button = toggleRoot?.querySelector<HTMLButtonElement>(
+          "[data-favorite-button]"
+        );
+        if (button) {
+          button.setAttribute("aria-pressed", String(isFavorite));
+        }
       });
+    };
+
+    const applyFilters = () => {
+      const name =
+        form?.querySelector<HTMLSelectElement>("[name=\"name\"]")?.value ??
+        "";
+      const type =
+        form?.querySelector<HTMLSelectElement>("[name=\"type\"]")?.value ??
+        "";
+      const favoritesOnly = Boolean(
+        form?.querySelector<HTMLInputElement>("[name=\"favoritesOnly\"]")
+          ?.checked
+      );
+
+      cards.forEach((card) => {
+        const matchesName = !name || card.dataset.name === name;
+        const matchesType = !type || card.dataset.type === type;
+        const matchesFavorite =
+          !favoritesOnly || card.dataset.favorite === "true";
+        card.style.display =
+          matchesName && matchesType && matchesFavorite ? "" : "none";
+      });
+    };
+
+    const payload = loadFavorites();
+    applyFavorites(payload.items);
+    applyFilters();
+
+    form?.addEventListener("change", applyFilters);
+
+    const unsubscribe = subscribeToFavorites((detail) => {
+      if (!detail || !detail.payload) return;
+      applyFavorites(detail.payload.items);
+      applyFilters();
+    });
+
+    window.addEventListener(
+      "astro:before-swap",
+      () => {
+        unsubscribe?.();
+      },
+      { once: true }
+    );
   </script>
   <style>
     .resource-card__title a {

--- a/src/pages/warmups/index.astro
+++ b/src/pages/warmups/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import FilterDrawer from "../../components/FilterDrawer.astro";
+import FavoriteToggle from "../../components/FavoriteToggle.astro";
 import { getCollection } from "astro:content";
 const warmups = (await getCollection("warmups")).sort((a, b) =>
   a.data.name.localeCompare(b.data.name)
@@ -49,6 +50,7 @@ const minPeople = Array.from(
                   options: minPeople.map(String),
                 }
               : null,
+            { name: "favoritesOnly", label: "Favourites only", type: "checkbox" },
           ].filter(Boolean)}
         />
       </div>
@@ -65,10 +67,17 @@ const minPeople = Array.from(
                 ? String(warmup.data.minimumPeople)
                 : ""
             }
+            data-favorite="false"
           >
             <h2 class="resource-card__title">
               <a href={`/warmups/${warmup.slug}`}>{warmup.data.name}</a>
             </h2>
+            <FavoriteToggle
+              contentType="warmup"
+              slug={warmup.slug}
+              title={warmup.data.name}
+              description={warmup.data.shortDescription}
+            />
             <p class="resource-card__summary">{warmup.data.shortDescription}</p>
             <div class="meta-badges">
               {warmup.data.focus && <span class="meta-badge">Focus · {warmup.data.focus}</span>}
@@ -83,27 +92,87 @@ const minPeople = Array.from(
       }
     </ul>
   </section>
-  <script>
-    const form = document.querySelector(".filter-form");
+  <script type="module" lang="ts">
+    import {
+      loadFavorites,
+      subscribeToFavorites,
+    } from "../../utils/favorites";
+
+    const form = document.querySelector<HTMLFormElement>(".filter-form");
     const list = document.getElementById("warmupList");
-    form &&
-      form.addEventListener("change", () => {
-        const nameInput = form.querySelector('[name="name"]');
-        const focusInput = form.querySelector('[name="focus"]');
-        const minPeopleInput = form.querySelector('[name="minimumPeople"]');
-        const name = nameInput ? nameInput.value : "";
-        const focus = focusInput ? focusInput.value : "";
-        const minPeople = minPeopleInput ? minPeopleInput.value : "";
-        Array.from(list?.children || []).forEach((li) => {
-          const el = li;
-          const matchesName = !name || el.dataset.name === name;
-          const matchesFocus = !focus || el.dataset.focus === focus;
-          const matchesMinPeople =
-            !minPeople || el.dataset.minimumPeople === minPeople;
-          el.style.display =
-            matchesName && matchesFocus && matchesMinPeople ? "" : "none";
-        });
+    const cards = list
+      ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
+      : [];
+
+    const applyFavorites = (items: Record<string, unknown>) => {
+      cards.forEach((card) => {
+        const toggleRoot = card.querySelector<HTMLElement>(
+          "[data-favorite-root]"
+        );
+        const key = toggleRoot?.dataset.favoriteKey ?? "";
+        const isFavorite = Boolean(key && items[key]);
+        card.dataset.favorite = String(isFavorite);
+        const button = toggleRoot?.querySelector<HTMLButtonElement>(
+          "[data-favorite-button]"
+        );
+        if (button) {
+          button.setAttribute("aria-pressed", String(isFavorite));
+        }
       });
+    };
+
+    const applyFilters = () => {
+      const name =
+        form?.querySelector<HTMLSelectElement>("[name=\"name\"]")?.value ??
+        "";
+      const focus =
+        form?.querySelector<HTMLSelectElement>("[name=\"focus\"]")?.value ??
+        "";
+      const minPeople =
+        form
+          ?.querySelector<HTMLSelectElement>("[name=\"minimumPeople\"]")
+          ?.value ?? "";
+      const favoritesOnly = Boolean(
+        form?.querySelector<HTMLInputElement>("[name=\"favoritesOnly\"]")
+          ?.checked
+      );
+
+      cards.forEach((card) => {
+        const matchesName = !name || card.dataset.name === name;
+        const matchesFocus = !focus || card.dataset.focus === focus;
+        const matchesMinPeople =
+          !minPeople || card.dataset.minimumPeople === minPeople;
+        const matchesFavorite =
+          !favoritesOnly || card.dataset.favorite === "true";
+        card.style.display =
+          matchesName &&
+          matchesFocus &&
+          matchesMinPeople &&
+          matchesFavorite
+            ? ""
+            : "none";
+      });
+    };
+
+    const payload = loadFavorites();
+    applyFavorites(payload.items);
+    applyFilters();
+
+    form?.addEventListener("change", applyFilters);
+
+    const unsubscribe = subscribeToFavorites((detail) => {
+      if (!detail || !detail.payload) return;
+      applyFavorites(detail.payload.items);
+      applyFilters();
+    });
+
+    window.addEventListener(
+      "astro:before-swap",
+      () => {
+        unsubscribe?.();
+      },
+      { once: true }
+    );
   </script>
   <style>
     .resource-card__title a {


### PR DESCRIPTION
## Summary
- render checkbox fields in the filter drawer with accessible markup
- embed the favorite toggle on exercise, warmup, and form cards and mirror favorite state across tabs
- add a favorites-only filter that hides non-favorited cards while respecting existing filters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6e3a0bac832a8d3e622c282c3933