### PR TITLE
Refine favorites UI and repair favorites-only filtering

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -637,38 +637,23 @@ textarea:focus {
 .favorite-toggle__button {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.85rem;
-  min-inline-size: 2.75rem;
-  min-block-size: 2.75rem;
+  justify-content: center;
+  inline-size: 2.5rem;
+  block-size: 2.5rem;
   border-radius: var(--radius-pill);
   border: 1px solid color-mix(in srgb, var(--color-accent) 18%, transparent);
-  background: color-mix(in srgb, var(--surface-panel) 80%, transparent);
-  color: color-mix(in srgb, var(--color-text) 78%, black 22%);
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  transition: background 0.2s ease, border-color 0.2s ease,
-    color 0.2s ease, transform 0.2s ease;
-}
-
-.favorite-toggle__button::before {
-  content: "";
-  inline-size: 1.1rem;
-  block-size: 1.1rem;
-  flex: none;
-  background: currentColor;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='black' viewBox='0 0 24 24'%3E%3Cpath d='M12 3.5l2.47 5.34 5.89.5-4.4 3.91 1.32 5.74L12 16.9l-5.28 2.09 1.32-5.74-4.4-3.91 5.89-.5z'/%3E%3C/svg%3E")
-    no-repeat center / contain;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='black' viewBox='0 0 24 24'%3E%3Cpath d='M12 3.5l2.47 5.34 5.89.5-4.4 3.91 1.32 5.74L12 16.9l-5.28 2.09 1.32-5.74-4.4-3.91 5.89-.5z'/%3E%3C/svg%3E")
-    no-repeat center / contain;
+  background: color-mix(in srgb, var(--surface-panel) 82%, black 18%);
+  color: color-mix(in srgb, var(--color-muted) 85%, black 15%);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .favorite-toggle__button:hover {
-  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  background: color-mix(in srgb, var(--surface-panel) 70%, transparent);
   border-color: color-mix(in srgb, var(--color-accent) 40%, transparent);
-  color: var(--color-accent);
+  color: color-mix(in srgb, var(--color-accent) 70%, white 30%);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(15, 6, 18, 0.3);
 }
 
 .favorite-toggle__button:active {
@@ -676,14 +661,14 @@ textarea:focus {
 }
 
 .favorite-toggle__button[aria-pressed="true"] {
-  background: color-mix(in srgb, var(--color-accent) 26%, transparent);
-  border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 35%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
   color: var(--color-accent);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 30%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 32%, transparent);
 }
 
 .favorite-toggle__button[aria-pressed="true"]:hover {
-  background: color-mix(in srgb, var(--color-accent) 32%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 42%, transparent);
 }
 
 .favorite-toggle__button:focus-visible {
@@ -693,9 +678,33 @@ textarea:focus {
 
 .favorite-toggle__button:disabled {
   cursor: not-allowed;
-  opacity: 0.65;
-  background: color-mix(in srgb, var(--surface-panel) 70%, transparent);
-  border-color: color-mix(in srgb, var(--color-text) 10%, transparent);
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.favorite-toggle__icon {
+  inline-size: 1.35rem;
+  block-size: 1.35rem;
+  display: block;
+}
+
+.favorite-toggle__icon-fill {
+  fill: currentColor;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.favorite-toggle__icon-outline {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.favorite-toggle__button[aria-pressed="true"] .favorite-toggle__icon-fill {
+  opacity: 1;
 }
 
 .favorite-toggle__fallback {
@@ -711,6 +720,9 @@ textarea:focus {
   }
   .favorite-toggle__button:active {
     transform: none;
+  }
+  .favorite-toggle__icon-fill {
+    transition: none;
   }
 }
 
@@ -744,13 +756,12 @@ textarea:focus {
     color: HighlightText;
   }
 
-  .favorite-toggle__button::before {
-    content: "★";
-    mask: none;
-    -webkit-mask: none;
-    background: none;
-    inline-size: auto;
-    block-size: auto;
+  .favorite-toggle__icon-fill {
+    opacity: 1;
+  }
+
+  .favorite-toggle__icon-outline {
+    stroke-width: 1;
   }
 }
 

--- a/src/components/FavoriteToggle.astro
+++ b/src/components/FavoriteToggle.astro
@@ -19,18 +19,14 @@ const resolvedTitle = title ?? "this item";
 const resolvedDescription = description ?? "";
 const key = contentType && slugValue ? favoriteKey(contentType, slugValue) : "";
 const hasKey = Boolean(key);
-const storageReady = isStorageReady();
+const storageReady = import.meta.env.SSR ? true : isStorageReady();
 const addLabel = "Save to favorites";
 const removeLabel = "Remove from favorites";
 const srAddLabel = `Add ${resolvedTitle} to favorites`;
 const srRemoveLabel = `Remove ${resolvedTitle} from favorites`;
 const statusAdd = `${resolvedTitle} added to favorites.`;
 const statusRemove = `${resolvedTitle} removed from favorites.`;
-const fallbackMessage = hasKey
-  ? storageReady
-    ? "Favorites will be ready once the page is fully loaded."
-    : "Favorites require local storage support in your browser."
-  : "Favorites are unavailable for this entry.";
+const fallbackMessage = hasKey ? "" : "Favorites are unavailable for this entry.";
 ---
 
 <div
@@ -47,10 +43,27 @@ const fallbackMessage = hasKey
     type="button"
     class="favorite-toggle__button"
     aria-pressed="false"
+    aria-label={addLabel}
     data-favorite-button
     disabled={!hasKey || !storageReady}
   >
-    <span aria-hidden="true" data-favorite-visible-text>{addLabel}</span>
+    <svg
+      class="favorite-toggle__icon"
+      viewBox="0 0 24 24"
+      role="presentation"
+      aria-hidden="true"
+      focusable="false"
+      data-favorite-icon
+    >
+      <path
+        class="favorite-toggle__icon-fill"
+        d="M12 3.5l2.47 5.34 5.89.5-4.4 3.91 1.32 5.74L12 16.9l-5.28 2.09 1.32-5.74-4.4-3.91 5.89-.5z"
+      />
+      <path
+        class="favorite-toggle__icon-outline"
+        d="M12 3.5l2.47 5.34 5.89.5-4.4 3.91 1.32 5.74L12 16.9l-5.28 2.09 1.32-5.74-4.4-3.91 5.89-.5z"
+      />
+    </svg>
     <span class="sr-only" data-favorite-sr-text>{srAddLabel}</span>
   </button>
   <span
@@ -59,7 +72,13 @@ const fallbackMessage = hasKey
     aria-live="polite"
     data-favorite-status
   ></span>
-  <span class="favorite-toggle__fallback" data-favorite-fallback>{fallbackMessage}</span>
+  <span
+    class="favorite-toggle__fallback"
+    data-favorite-fallback
+    hidden={fallbackMessage ? undefined : true}
+  >
+    {fallbackMessage}
+  </span>
 </div>
 
 <script
@@ -97,7 +116,6 @@ const fallbackMessage = hasKey
   root.dataset.favoriteEvent = FAVORITES_EVENT;
 
   const button = root.querySelector<HTMLButtonElement>("[data-favorite-button]");
-  const visibleText = root.querySelector<HTMLElement>("[data-favorite-visible-text]");
   const srText = root.querySelector<HTMLElement>("[data-favorite-sr-text]");
   const statusEl = root.querySelector<HTMLElement>("[data-favorite-status]");
   const fallbackEl = root.querySelector<HTMLElement>("[data-favorite-fallback]");
@@ -106,18 +124,21 @@ const fallbackMessage = hasKey
     if (button) {
       button.disabled = true;
       button.setAttribute("aria-pressed", "false");
-    }
-    if (visibleText) {
-      visibleText.textContent = addLabel;
+      button.setAttribute("aria-label", addLabel);
     }
     if (srText) {
       srText.textContent = srAddLabel;
     }
     if (fallbackEl) {
-      fallbackEl.hidden = false;
-      fallbackEl.textContent = message;
+      if (message) {
+        fallbackEl.hidden = false;
+        fallbackEl.textContent = message;
+      } else {
+        fallbackEl.hidden = true;
+        fallbackEl.textContent = "";
+      }
     }
-    if (statusEl) {
+    if (statusEl && message) {
       statusEl.textContent = message;
     }
   };
@@ -128,15 +149,13 @@ const fallbackMessage = hasKey
   }
 
   if (!isStorageReady()) {
-    disableControl("Favorites require local storage support in your browser.");
+    disableControl("Favorites are unavailable right now.");
     return;
   }
 
   const toggleText = (isFavorite: boolean) => {
     button.setAttribute("aria-pressed", String(isFavorite));
-    if (visibleText) {
-      visibleText.textContent = isFavorite ? removeLabel : addLabel;
-    }
+    button.setAttribute("aria-label", isFavorite ? removeLabel : addLabel);
     if (srText) {
       srText.textContent = isFavorite ? srRemoveLabel : srAddLabel;
     }
@@ -155,7 +174,8 @@ const fallbackMessage = hasKey
   };
 
   if (fallbackEl) {
-    fallbackEl.hidden = true;
+    fallbackEl.hidden = !fallbackMessage;
+    fallbackEl.textContent = fallbackMessage;
   }
 
   button.disabled = false;
@@ -192,7 +212,7 @@ const fallbackMessage = hasKey
     clickController.abort();
     unsubscribe?.();
     if (fallbackEl) {
-      fallbackEl.hidden = false;
+      fallbackEl.hidden = !fallbackMessage;
       fallbackEl.textContent = fallbackMessage;
     }
   };
@@ -227,41 +247,89 @@ const fallbackMessage = hasKey
   }
 
   .favorite-toggle__button {
-    border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    background: color-mix(in srgb, var(--surface-raised, #1f1521) 70%, black 30%);
-    color: var(--color-heading, #fff5f7);
-    padding: 0.35rem 0.9rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    justify-content: center;
+    inline-size: 2.5rem;
+    block-size: 2.5rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--color-accent, #ff2f55) 18%, transparent);
+    background: color-mix(in srgb, var(--surface-panel, #1f1521) 82%, black 18%);
+    color: color-mix(in srgb, var(--color-muted, #cbbfca) 85%, black 15%);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+      background 0.2s ease, color 0.2s ease;
   }
 
   .favorite-toggle__button:hover,
   .favorite-toggle__button:focus-visible {
-    border-color: color-mix(in srgb, var(--color-accent, #ff2f55) 45%, transparent);
+    border-color: color-mix(in srgb, var(--color-accent, #ff2f55) 40%, transparent);
+    background: color-mix(in srgb, var(--surface-panel, #1f1521) 70%, transparent);
+    color: color-mix(in srgb, var(--color-accent, #ff2f55) 70%, white 30%);
     transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(15, 6, 18, 0.35);
+    box-shadow: 0 8px 18px rgba(15, 6, 18, 0.3);
+  }
+
+  .favorite-toggle__button:focus-visible {
+    outline: none;
   }
 
   .favorite-toggle__button[aria-pressed="true"] {
-    border-color: color-mix(in srgb, var(--color-accent, #ff2f55) 65%, transparent);
     background: color-mix(in srgb, var(--color-accent, #ff2f55) 35%, transparent);
+    border-color: color-mix(in srgb, var(--color-accent, #ff2f55) 55%, transparent);
+    color: var(--color-accent, #ff2f55);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent, #ff2f55) 32%, transparent);
   }
 
   .favorite-toggle__button:disabled {
-    opacity: 0.6;
+    opacity: 0.55;
     cursor: not-allowed;
     transform: none;
     box-shadow: none;
   }
 
+  .favorite-toggle__icon {
+    inline-size: 1.35rem;
+    block-size: 1.35rem;
+    display: block;
+    transition: color 0.2s ease;
+  }
+
+  .favorite-toggle__icon-fill {
+    fill: currentColor;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .favorite-toggle__icon-outline {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .favorite-toggle__button[aria-pressed="true"] .favorite-toggle__icon-fill {
+    opacity: 1;
+  }
+
   .favorite-toggle__fallback {
     font-size: 0.85rem;
     color: color-mix(in srgb, var(--color-muted, #cbbfca) 80%, black 20%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .favorite-toggle__button {
+      transition: none;
+    }
+
+    .favorite-toggle__button:hover,
+    .favorite-toggle__button:focus-visible {
+      transform: none;
+      box-shadow: none;
+    }
+
+    .favorite-toggle__icon-fill {
+      transition: none;
+    }
   }
 </style>

--- a/src/pages/exercises/index.astro
+++ b/src/pages/exercises/index.astro
@@ -105,13 +105,19 @@ const minPeople = Array.from(
       ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
       : [];
 
+    let favoritesState: Record<string, unknown> = {};
+
+    const resolveFavorite = (card: HTMLLIElement) => {
+      const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
+      const key = toggleRoot?.dataset.favoriteKey ?? "";
+      const isFavorite = Boolean(key && favoritesState[key]);
+      return { toggleRoot, key, isFavorite } as const;
+    };
+
     const applyFavorites = (items: Record<string, unknown>) => {
+      favoritesState = items ?? {};
       cards.forEach((card) => {
-        const toggleRoot = card.querySelector<HTMLElement>(
-          "[data-favorite-root]"
-        );
-        const key = toggleRoot?.dataset.favoriteKey ?? "";
-        const isFavorite = Boolean(key && items[key]);
+        const { toggleRoot, isFavorite } = resolveFavorite(card);
         card.dataset.favorite = String(isFavorite);
         const button = toggleRoot?.querySelector<HTMLButtonElement>(
           "[data-favorite-button]"
@@ -139,19 +145,16 @@ const minPeople = Array.from(
       );
 
       cards.forEach((card) => {
+        const { isFavorite } = resolveFavorite(card);
+        card.dataset.favorite = String(isFavorite);
         const matchesName = !name || card.dataset.name === name;
         const matchesFocus = !focus || card.dataset.focus === focus;
         const matchesMinPeople =
           !minPeople || card.dataset.minimumPeople === minPeople;
-        const matchesFavorite =
-          !favoritesOnly || card.dataset.favorite === "true";
-        card.style.display =
-          matchesName &&
-          matchesFocus &&
-          matchesMinPeople &&
-          matchesFavorite
-            ? ""
-            : "none";
+        const matchesFavorite = !favoritesOnly || isFavorite;
+        const shouldShow =
+          matchesName && matchesFocus && matchesMinPeople && matchesFavorite;
+        card.hidden = !shouldShow;
       });
     };
 

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -77,13 +77,19 @@ const types = Array.from(
       ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
       : [];
 
+    let favoritesState: Record<string, unknown> = {};
+
+    const resolveFavorite = (card: HTMLLIElement) => {
+      const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
+      const key = toggleRoot?.dataset.favoriteKey ?? "";
+      const isFavorite = Boolean(key && favoritesState[key]);
+      return { toggleRoot, key, isFavorite } as const;
+    };
+
     const applyFavorites = (items: Record<string, unknown>) => {
+      favoritesState = items ?? {};
       cards.forEach((card) => {
-        const toggleRoot = card.querySelector<HTMLElement>(
-          "[data-favorite-root]"
-        );
-        const key = toggleRoot?.dataset.favoriteKey ?? "";
-        const isFavorite = Boolean(key && items[key]);
+        const { toggleRoot, isFavorite } = resolveFavorite(card);
         card.dataset.favorite = String(isFavorite);
         const button = toggleRoot?.querySelector<HTMLButtonElement>(
           "[data-favorite-button]"
@@ -107,12 +113,13 @@ const types = Array.from(
       );
 
       cards.forEach((card) => {
+        const { isFavorite } = resolveFavorite(card);
+        card.dataset.favorite = String(isFavorite);
         const matchesName = !name || card.dataset.name === name;
         const matchesType = !type || card.dataset.type === type;
-        const matchesFavorite =
-          !favoritesOnly || card.dataset.favorite === "true";
-        card.style.display =
-          matchesName && matchesType && matchesFavorite ? "" : "none";
+        const matchesFavorite = !favoritesOnly || isFavorite;
+        const shouldShow = matchesName && matchesType && matchesFavorite;
+        card.hidden = !shouldShow;
       });
     };
 

--- a/src/pages/warmups/index.astro
+++ b/src/pages/warmups/index.astro
@@ -104,13 +104,19 @@ const minPeople = Array.from(
       ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
       : [];
 
+    let favoritesState: Record<string, unknown> = {};
+
+    const resolveFavorite = (card: HTMLLIElement) => {
+      const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
+      const key = toggleRoot?.dataset.favoriteKey ?? "";
+      const isFavorite = Boolean(key && favoritesState[key]);
+      return { toggleRoot, key, isFavorite } as const;
+    };
+
     const applyFavorites = (items: Record<string, unknown>) => {
+      favoritesState = items ?? {};
       cards.forEach((card) => {
-        const toggleRoot = card.querySelector<HTMLElement>(
-          "[data-favorite-root]"
-        );
-        const key = toggleRoot?.dataset.favoriteKey ?? "";
-        const isFavorite = Boolean(key && items[key]);
+        const { toggleRoot, isFavorite } = resolveFavorite(card);
         card.dataset.favorite = String(isFavorite);
         const button = toggleRoot?.querySelector<HTMLButtonElement>(
           "[data-favorite-button]"
@@ -138,19 +144,16 @@ const minPeople = Array.from(
       );
 
       cards.forEach((card) => {
+        const { isFavorite } = resolveFavorite(card);
+        card.dataset.favorite = String(isFavorite);
         const matchesName = !name || card.dataset.name === name;
         const matchesFocus = !focus || card.dataset.focus === focus;
         const matchesMinPeople =
           !minPeople || card.dataset.minimumPeople === minPeople;
-        const matchesFavorite =
-          !favoritesOnly || card.dataset.favorite === "true";
-        card.style.display =
-          matchesName &&
-          matchesFocus &&
-          matchesMinPeople &&
-          matchesFavorite
-            ? ""
-            : "none";
+        const matchesFavorite = !favoritesOnly || isFavorite;
+        const shouldShow =
+          matchesName && matchesFocus && matchesMinPeople && matchesFavorite;
+        card.hidden = !shouldShow;
       });
     };
 


### PR DESCRIPTION
## Summary
- replace the favorites toggle label with an icon-only control and remove the local storage warning
- ensure resource listings sync card favorite state and hide unfavorited items when the favorites-only filter is enabled
- refresh the shared theme styles so the new toggle design renders consistently

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da738e3cec832a9c70348ee7832316