### PR TITLE
Refactor resource list filtering into shared utility

### DIFF
--- a/src/pages/exercises/index.astro
+++ b/src/pages/exercises/index.astro
@@ -94,89 +94,16 @@ const minPeople = Array.from(
     </ul>
   </section>
   <script type="module" lang="ts">
-    import {
-      loadFavorites,
-      subscribeToFavorites,
-    } from "../../utils/favorites";
+    import { setupResourceListFiltering } from "../../utils/resourceFilters";
 
-    const form = document.querySelector<HTMLFormElement>(".filter-form");
-    const list = document.getElementById("exerciseList");
-    const cards = list
-      ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
-      : [];
-
-    let favoritesState: Record<string, unknown> = {};
-
-    const resolveFavorite = (card: HTMLLIElement) => {
-      const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
-      const key = toggleRoot?.dataset.favoriteKey ?? "";
-      const isFavorite = Boolean(key && favoritesState[key]);
-      return { toggleRoot, key, isFavorite } as const;
-    };
-
-    const applyFavorites = (items: Record<string, unknown>) => {
-      favoritesState = items ?? {};
-      cards.forEach((card) => {
-        const { toggleRoot, isFavorite } = resolveFavorite(card);
-        card.dataset.favorite = String(isFavorite);
-        const button = toggleRoot?.querySelector<HTMLButtonElement>(
-          "[data-favorite-button]"
-        );
-        if (button) {
-          button.setAttribute("aria-pressed", String(isFavorite));
-        }
-      });
-    };
-
-    const applyFilters = () => {
-      const name =
-        form?.querySelector<HTMLSelectElement>("[name=\"name\"]")?.value ??
-        "";
-      const focus =
-        form?.querySelector<HTMLSelectElement>("[name=\"focus\"]")?.value ??
-        "";
-      const minPeople =
-        form
-          ?.querySelector<HTMLSelectElement>("[name=\"minimumPeople\"]")
-          ?.value ?? "";
-      const favoritesOnly = Boolean(
-        form?.querySelector<HTMLInputElement>("[name=\"favoritesOnly\"]")
-          ?.checked
-      );
-
-      cards.forEach((card) => {
-        const { isFavorite } = resolveFavorite(card);
-        card.dataset.favorite = String(isFavorite);
-        const matchesName = !name || card.dataset.name === name;
-        const matchesFocus = !focus || card.dataset.focus === focus;
-        const matchesMinPeople =
-          !minPeople || card.dataset.minimumPeople === minPeople;
-        const matchesFavorite = !favoritesOnly || isFavorite;
-        const shouldShow =
-          matchesName && matchesFocus && matchesMinPeople && matchesFavorite;
-        card.hidden = !shouldShow;
-      });
-    };
-
-    const payload = loadFavorites();
-    applyFavorites(payload.items);
-    applyFilters();
-
-    form?.addEventListener("change", applyFilters);
-
-    const unsubscribe = subscribeToFavorites((detail) => {
-      if (!detail || !detail.payload) return;
-      applyFavorites(detail.payload.items);
-      applyFilters();
+    setupResourceListFiltering({
+      listSelector: "#exerciseList",
+      equalityFilters: [
+        { field: "name" },
+        { field: "focus" },
+        { field: "minimumPeople" },
+      ],
     });
-
-    window.addEventListener(
-      "astro:before-swap",
-      () => {
-        unsubscribe?.();
-      },
-      { once: true }
-    );
   </script>
   <style>
     .resource-card__title a {

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -66,82 +66,15 @@ const types = Array.from(
     </ul>
   </section>
   <script type="module" lang="ts">
-    import {
-      loadFavorites,
-      subscribeToFavorites,
-    } from "../../utils/favorites";
+    import { setupResourceListFiltering } from "../../utils/resourceFilters";
 
-    const form = document.querySelector<HTMLFormElement>(".filter-form");
-    const list = document.getElementById("formList");
-    const cards = list
-      ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
-      : [];
-
-    let favoritesState: Record<string, unknown> = {};
-
-    const resolveFavorite = (card: HTMLLIElement) => {
-      const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
-      const key = toggleRoot?.dataset.favoriteKey ?? "";
-      const isFavorite = Boolean(key && favoritesState[key]);
-      return { toggleRoot, key, isFavorite } as const;
-    };
-
-    const applyFavorites = (items: Record<string, unknown>) => {
-      favoritesState = items ?? {};
-      cards.forEach((card) => {
-        const { toggleRoot, isFavorite } = resolveFavorite(card);
-        card.dataset.favorite = String(isFavorite);
-        const button = toggleRoot?.querySelector<HTMLButtonElement>(
-          "[data-favorite-button]"
-        );
-        if (button) {
-          button.setAttribute("aria-pressed", String(isFavorite));
-        }
-      });
-    };
-
-    const applyFilters = () => {
-      const name =
-        form?.querySelector<HTMLSelectElement>("[name=\"name\"]")?.value ??
-        "";
-      const type =
-        form?.querySelector<HTMLSelectElement>("[name=\"type\"]")?.value ??
-        "";
-      const favoritesOnly = Boolean(
-        form?.querySelector<HTMLInputElement>("[name=\"favoritesOnly\"]")
-          ?.checked
-      );
-
-      cards.forEach((card) => {
-        const { isFavorite } = resolveFavorite(card);
-        card.dataset.favorite = String(isFavorite);
-        const matchesName = !name || card.dataset.name === name;
-        const matchesType = !type || card.dataset.type === type;
-        const matchesFavorite = !favoritesOnly || isFavorite;
-        const shouldShow = matchesName && matchesType && matchesFavorite;
-        card.hidden = !shouldShow;
-      });
-    };
-
-    const payload = loadFavorites();
-    applyFavorites(payload.items);
-    applyFilters();
-
-    form?.addEventListener("change", applyFilters);
-
-    const unsubscribe = subscribeToFavorites((detail) => {
-      if (!detail || !detail.payload) return;
-      applyFavorites(detail.payload.items);
-      applyFilters();
+    setupResourceListFiltering({
+      listSelector: "#formList",
+      equalityFilters: [
+        { field: "name" },
+        { field: "type" },
+      ],
     });
-
-    window.addEventListener(
-      "astro:before-swap",
-      () => {
-        unsubscribe?.();
-      },
-      { once: true }
-    );
   </script>
   <style>
     .resource-card__title a {

--- a/src/pages/warmups/index.astro
+++ b/src/pages/warmups/index.astro
@@ -93,89 +93,16 @@ const minPeople = Array.from(
     </ul>
   </section>
   <script type="module" lang="ts">
-    import {
-      loadFavorites,
-      subscribeToFavorites,
-    } from "../../utils/favorites";
+    import { setupResourceListFiltering } from "../../utils/resourceFilters";
 
-    const form = document.querySelector<HTMLFormElement>(".filter-form");
-    const list = document.getElementById("warmupList");
-    const cards = list
-      ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
-      : [];
-
-    let favoritesState: Record<string, unknown> = {};
-
-    const resolveFavorite = (card: HTMLLIElement) => {
-      const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
-      const key = toggleRoot?.dataset.favoriteKey ?? "";
-      const isFavorite = Boolean(key && favoritesState[key]);
-      return { toggleRoot, key, isFavorite } as const;
-    };
-
-    const applyFavorites = (items: Record<string, unknown>) => {
-      favoritesState = items ?? {};
-      cards.forEach((card) => {
-        const { toggleRoot, isFavorite } = resolveFavorite(card);
-        card.dataset.favorite = String(isFavorite);
-        const button = toggleRoot?.querySelector<HTMLButtonElement>(
-          "[data-favorite-button]"
-        );
-        if (button) {
-          button.setAttribute("aria-pressed", String(isFavorite));
-        }
-      });
-    };
-
-    const applyFilters = () => {
-      const name =
-        form?.querySelector<HTMLSelectElement>("[name=\"name\"]")?.value ??
-        "";
-      const focus =
-        form?.querySelector<HTMLSelectElement>("[name=\"focus\"]")?.value ??
-        "";
-      const minPeople =
-        form
-          ?.querySelector<HTMLSelectElement>("[name=\"minimumPeople\"]")
-          ?.value ?? "";
-      const favoritesOnly = Boolean(
-        form?.querySelector<HTMLInputElement>("[name=\"favoritesOnly\"]")
-          ?.checked
-      );
-
-      cards.forEach((card) => {
-        const { isFavorite } = resolveFavorite(card);
-        card.dataset.favorite = String(isFavorite);
-        const matchesName = !name || card.dataset.name === name;
-        const matchesFocus = !focus || card.dataset.focus === focus;
-        const matchesMinPeople =
-          !minPeople || card.dataset.minimumPeople === minPeople;
-        const matchesFavorite = !favoritesOnly || isFavorite;
-        const shouldShow =
-          matchesName && matchesFocus && matchesMinPeople && matchesFavorite;
-        card.hidden = !shouldShow;
-      });
-    };
-
-    const payload = loadFavorites();
-    applyFavorites(payload.items);
-    applyFilters();
-
-    form?.addEventListener("change", applyFilters);
-
-    const unsubscribe = subscribeToFavorites((detail) => {
-      if (!detail || !detail.payload) return;
-      applyFavorites(detail.payload.items);
-      applyFilters();
+    setupResourceListFiltering({
+      listSelector: "#warmupList",
+      equalityFilters: [
+        { field: "name" },
+        { field: "focus" },
+        { field: "minimumPeople" },
+      ],
     });
-
-    window.addEventListener(
-      "astro:before-swap",
-      () => {
-        unsubscribe?.();
-      },
-      { once: true }
-    );
   </script>
   <style>
     .resource-card__title a {

--- a/src/utils/resourceFilters.ts
+++ b/src/utils/resourceFilters.ts
@@ -1,0 +1,119 @@
+import {
+  loadFavorites,
+  subscribeToFavorites,
+} from "./favorites";
+
+interface EqualityFilterDefinition {
+  field: string;
+  dataAttribute?: string;
+}
+
+interface SetupResourceListFilteringOptions {
+  listSelector: string;
+  formSelector?: string;
+  favoritesField?: string;
+  equalityFilters?: EqualityFilterDefinition[];
+}
+
+type FavoritesState = Record<string, unknown>;
+
+type Nullable<T> = T | null | undefined;
+
+export function setupResourceListFiltering({
+  listSelector,
+  formSelector = ".filter-form",
+  favoritesField = "favoritesOnly",
+  equalityFilters = [],
+}: SetupResourceListFilteringOptions): () => void {
+  const list = document.querySelector<HTMLElement>(listSelector);
+  const form = document.querySelector<HTMLFormElement>(formSelector);
+  const cards = list
+    ? Array.from(list.querySelectorAll<HTMLLIElement>(".resource-card"))
+    : [];
+
+  if (!cards.length) {
+    return () => {};
+  }
+
+  let favoritesState: FavoritesState = {};
+
+  const resolveFavorite = (card: HTMLLIElement) => {
+    const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
+    const key = toggleRoot?.dataset.favoriteKey ?? "";
+    const isFavorite = Boolean(key && favoritesState[key]);
+    return { toggleRoot, key, isFavorite } as const;
+  };
+
+  const applyFavorites = (items: FavoritesState) => {
+    favoritesState = items ?? {};
+    cards.forEach((card) => {
+      const { toggleRoot, isFavorite } = resolveFavorite(card);
+      card.dataset.favorite = String(isFavorite);
+      const button = toggleRoot?.querySelector<HTMLButtonElement>(
+        "[data-favorite-button]"
+      );
+      if (button) {
+        button.setAttribute("aria-pressed", String(isFavorite));
+      }
+    });
+  };
+
+  const getFormValue = (
+    formData: Nullable<FormData>,
+    field: string
+  ): string => {
+    if (!formData) {
+      return "";
+    }
+    const value = formData.get(field);
+    return typeof value === "string" ? value : value != null ? String(value) : "";
+  };
+
+  const applyFilters = () => {
+    const formData = form ? new FormData(form) : null;
+
+    const activeFilters = equalityFilters.map((filter) => {
+      const attribute = filter.dataAttribute ?? filter.field;
+      const value = getFormValue(formData, filter.field);
+      return { attribute, value };
+    });
+
+    const favoritesOnly = Boolean(
+      favoritesField && formData ? formData.has(favoritesField) : false
+    );
+
+    cards.forEach((card) => {
+      const { isFavorite } = resolveFavorite(card);
+      const matchesFavorites = !favoritesOnly || isFavorite;
+      const matchesEquality = activeFilters.every(({ attribute, value }) => {
+        if (!value) {
+          return true;
+        }
+        const dataset = card.dataset as Record<string, string | undefined>;
+        return (dataset[attribute] ?? "") === value;
+      });
+      card.hidden = !(matchesFavorites && matchesEquality);
+    });
+  };
+
+  const payload = loadFavorites();
+  applyFavorites(payload.items);
+  applyFilters();
+
+  form?.addEventListener("change", applyFilters);
+
+  const unsubscribe = subscribeToFavorites((detail) => {
+    if (!detail || !detail.payload) return;
+    applyFavorites(detail.payload.items);
+    applyFilters();
+  });
+
+  const cleanup = () => {
+    form?.removeEventListener("change", applyFilters);
+    unsubscribe?.();
+  };
+
+  window.addEventListener("astro:before-swap", cleanup, { once: true });
+
+  return cleanup;
+}


### PR DESCRIPTION
## Summary
- extract a shared resource list filtering helper that manages favorites and form-driven filters
- update exercises, warmups, and forms pages to use the shared helper and reduce duplicated DOM scripting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68da758218bc832a98dbe5fb59700fe5