### PR TITLE
Improve theme contrast coverage and testing

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -2,7 +2,6 @@
 @import "https://unpkg.com/open-props@latest/open-props.min.css";
 
 :root {
-  color-scheme: dark;
   accent-color: var(--color-accent);
   --font-base: var(
     --font-sans,
@@ -16,32 +15,6 @@
   --font-display: "Epilogue", var(--font-base);
   --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
     Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --surface-color: color-mix(in srgb, var(--gray-12, #120910) 88%, black 12%);
-  --surface-raised: color-mix(in srgb, var(--surface-color) 92%, black 8%);
-  --surface-panel: color-mix(in srgb, var(--surface-color) 96%, black 4%);
-  --color-background: color-mix(in srgb, var(--gray-12, #0a050b) 95%, black 5%);
-  --color-text: var(--gray-1, #f9f6f8);
-  --color-heading: var(--gray-0, #fff5f7);
-  --color-muted: color-mix(in srgb, var(--gray-4, #cbbfca) 88%, white 12%);
-  --color-muted-strong: color-mix(
-    in srgb,
-    var(--gray-3, #f1d5dc) 82%,
-    white 18%
-  );
-  --color-accent: var(--red-6, #ff2f55);
-  --color-accent-soft: var(--red-5, #ff536c);
-  --color-accent-glow: color-mix(
-    in srgb,
-    var(--red-5, #ff536c) 60%,
-    transparent
-  );
-  --color-border-subtle: color-mix(in srgb, var(--color-text) 8%, transparent);
-  --muted-color: color-mix(in srgb, var(--color-text) 70%, black 30%);
-  --muted-border-color: color-mix(in srgb, var(--color-text) 12%, transparent);
-  --contrast: var(--color-accent);
-  --contrast-hover: color-mix(in srgb, var(--color-accent) 90%, white 10%);
-  --shadow-soft: var(--shadow-5, 0 18px 42px rgba(5, 2, 8, 0.45));
-  --shadow-hard: var(--shadow-6, 0 24px 68px rgba(5, 2, 10, 0.6));
   --radius-md: var(--radius-4, 18px);
   --radius-lg: var(--radius-6, 28px);
   --radius-pill: var(--radius-round, 999px);
@@ -50,6 +23,102 @@
   --container-max: min(1100px, 100vw - clamp(2rem, 6vw, 4rem));
   --focus-ring: 0 0 0 3px
     color-mix(in srgb, var(--color-accent) 35%, transparent);
+  --contrast: var(--color-accent);
+  --contrast-hover: color-mix(
+    in srgb,
+    var(--color-accent) 88%,
+    var(--color-background, white) 12%
+  );
+  --link-color: var(--color-accent-soft);
+  --link-color-hover: var(--color-accent);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --surface-color: #111827;
+  --surface-raised: color-mix(in srgb, #1f2937 88%, #020617 12%);
+  --surface-panel: color-mix(in srgb, #1f2937 80%, #020617 20%);
+  --color-background: #050b19;
+  --color-text: #e2e8f0;
+  --color-heading: #f8fafc;
+  --color-muted: color-mix(in srgb, #94a3b8 78%, white 22%);
+  --color-muted-strong: color-mix(in srgb, #bae6fd 68%, white 32%);
+  --color-accent: #0f6abf;
+  --color-accent-soft: #4cc4ff;
+  --color-accent-glow: color-mix(in srgb, var(--color-accent) 52%, transparent);
+  --link-color: #4cc4ff;
+  --link-color-hover: #78d0ff;
+  --color-on-accent: #f8fafc;
+  --color-border-subtle: color-mix(in srgb, var(--color-text) 10%, transparent);
+  --muted-color: color-mix(in srgb, var(--color-text) 65%, black 35%);
+  --muted-border-color: color-mix(in srgb, var(--color-text) 15%, transparent);
+  --border-elevated: color-mix(in srgb, var(--color-text) 16%, transparent);
+  --border-elevated-strong: color-mix(in srgb, var(--color-text) 22%, transparent);
+  --accent-shadow-soft: color-mix(in srgb, var(--color-accent) 24%, transparent);
+  --accent-shadow-strong: color-mix(in srgb, var(--color-accent) 36%, transparent);
+  --shadow-soft: 0 18px 42px rgba(12, 18, 38, 0.45);
+  --shadow-hard: 0 24px 68px rgba(5, 9, 23, 0.6);
+  --body-gradient: radial-gradient(
+      110% 120% at 12% -10%,
+      color-mix(in srgb, var(--color-accent) 22%, transparent) 0%,
+      transparent 58%
+    ),
+    radial-gradient(
+      90% 130% at 95% -18%,
+      color-mix(in srgb, var(--color-accent-soft) 18%, transparent) 0%,
+      transparent 60%
+    ),
+    linear-gradient(160deg, #020910 0%, #03131f 55%, #020b13 100%);
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --surface-color: #f5fbff;
+  --surface-raised: color-mix(in srgb, #ffffff 86%, #d8f3ff 14%);
+  --surface-panel: color-mix(in srgb, #ffffff 92%, #d8f8ff 8%);
+  --color-background: #ecfeff;
+  --color-text: #1f2937;
+  --color-heading: #111827;
+  --color-muted: color-mix(
+    in srgb,
+    var(--color-text) 85%,
+    var(--color-background) 15%
+  );
+  --color-muted-strong: color-mix(
+    in srgb,
+    var(--color-text) 92%,
+    var(--color-background) 8%
+  );
+  --color-accent: #0f4c81;
+  --color-accent-soft: #1d6fb8;
+  --color-accent-glow: color-mix(in srgb, var(--color-accent) 26%, transparent);
+  --color-on-accent: #f8f9ff;
+  --link-color: #1d6fb8;
+  --link-color-hover: #0f4c81;
+  --color-border-subtle: color-mix(in srgb, var(--color-text) 18%, transparent);
+  --muted-color: color-mix(
+    in srgb,
+    var(--color-text) 88%,
+    var(--color-background) 12%
+  );
+  --muted-border-color: color-mix(in srgb, var(--color-text) 18%, transparent);
+  --border-elevated: color-mix(in srgb, var(--color-text) 24%, transparent);
+  --border-elevated-strong: color-mix(in srgb, var(--color-text) 32%, transparent);
+  --accent-shadow-soft: color-mix(in srgb, var(--color-accent) 26%, transparent);
+  --accent-shadow-strong: color-mix(in srgb, var(--color-accent) 36%, transparent);
+  --shadow-soft: 0 18px 42px rgba(14, 165, 233, 0.18);
+  --shadow-hard: 0 24px 68px rgba(15, 23, 42, 0.14);
+  --body-gradient: radial-gradient(
+      120% 140% at -5% -20%,
+      color-mix(in srgb, var(--color-accent) 12%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      85% 120% at 110% -10%,
+      color-mix(in srgb, var(--color-accent-soft) 14%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(170deg, #f8fdff 0%, #edf6ff 55%, #e7fff9 100%);
 }
 
 *,
@@ -66,17 +135,7 @@ body {
   line-height: var(--font-lineheight-3, 1.6);
   color: var(--color-text);
   background-color: var(--color-background);
-  background-image: radial-gradient(
-      110% 120% at 10% 0%,
-      color-mix(in srgb, var(--color-accent) 20%, transparent) 0%,
-      transparent 60%
-    ),
-    radial-gradient(
-      90% 120% at 100% -10%,
-      color-mix(in srgb, var(--color-accent-soft) 16%, transparent) 0%,
-      transparent 55%
-    ),
-    linear-gradient(160deg, #040206 0%, #100811 48%, #070308 100%);
+  background-image: var(--body-gradient);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -85,24 +144,25 @@ main {
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--color-accent) 75%, black);
-  color: white;
+  background: color-mix(in srgb, var(--color-accent) 75%, transparent);
+  color: var(--color-on-accent);
 }
 
 a {
-  color: var(--color-accent-soft);
+  color: var(--link-color);
   text-decoration: none;
   transition: color 0.2s ease, text-shadow 0.2s ease;
 }
 a:hover,
 a:focus-visible {
-  color: var(--color-accent);
-  text-shadow: 0 0 12px rgba(255, 83, 108, 0.45);
+  color: var(--link-color-hover);
+  text-shadow: 0 0 12px
+    color-mix(in srgb, var(--link-color-hover) 35%, transparent);
 }
 
 p {
   margin: 0 0 1rem;
-  color: color-mix(in srgb, var(--color-text) 92%, black 8%);
+  color: color-mix(in srgb, var(--color-text) 92%, var(--color-background) 8%);
 }
 
 .sr-only {
@@ -153,27 +213,44 @@ button,
   gap: 0.5rem;
   padding: 0.65rem 1.35rem;
   border-radius: var(--radius-pill);
-  border: 1px solid transparent;
+  border: 1px solid var(--color-border-subtle);
   font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   text-transform: uppercase;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
     border-color 0.2s ease, color 0.2s ease;
-  background: color-mix(in srgb, var(--surface-raised) 72%, black 28%);
+  background: color-mix(
+    in srgb,
+    var(--surface-raised) 82%,
+    var(--color-background) 18%
+  );
   color: var(--color-heading);
-  box-shadow: 0 12px 28px rgba(12, 4, 16, 0.4);
+  box-shadow: 0 12px 28px color-mix(
+      in srgb,
+      var(--surface-color) 35%,
+      transparent
+    );
 }
 
 .button:hover,
 .button:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 16px 36px rgba(12, 4, 16, 0.5);
+  box-shadow: 0 16px 36px color-mix(
+      in srgb,
+      var(--surface-color) 45%,
+      transparent
+    );
 }
 
 .button:focus-visible {
   outline: none;
-  box-shadow: 0 16px 36px rgba(12, 4, 16, 0.5), var(--focus-ring);
+  box-shadow: 0 16px 36px color-mix(
+        in srgb,
+        var(--surface-color) 45%,
+        transparent
+      ),
+    var(--focus-ring);
 }
 
 .button:disabled {
@@ -186,24 +263,33 @@ button,
 .button--accent {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--color-accent) 82%, white 18%),
+    color-mix(
+      in srgb,
+      var(--color-accent) 92%,
+      var(--color-background) 8%
+    ),
     var(--color-accent)
   );
-  color: #140408;
-  border: 1px solid color-mix(in srgb, var(--color-accent) 40%, white 12%);
-  box-shadow: 0 18px 38px rgba(255, 63, 94, 0.45);
+  color: var(--color-on-accent);
+  border: 1px solid
+    color-mix(in srgb, var(--color-accent) 55%, transparent);
+  box-shadow: 0 18px 38px var(--accent-shadow-soft);
 }
 
 .button--accent:hover {
-  box-shadow: 0 22px 44px rgba(255, 63, 94, 0.5);
+  box-shadow: 0 22px 44px var(--accent-shadow-strong);
 }
 
 .button--accent:focus-visible {
-  box-shadow: 0 22px 44px rgba(255, 63, 94, 0.5), var(--focus-ring);
+  box-shadow: 0 22px 44px var(--accent-shadow-strong), var(--focus-ring);
 }
 
 .button--surface {
-  background: color-mix(in srgb, var(--surface-panel) 88%, black 12%);
+  background: color-mix(
+    in srgb,
+    var(--surface-panel) 88%,
+    var(--color-background) 12%
+  );
   border: 1px solid var(--color-border-subtle);
   color: var(--color-heading);
 }
@@ -214,7 +300,11 @@ button,
     var(--color-accent) 35%,
     var(--color-border-subtle)
   );
-  box-shadow: 0 14px 32px rgba(12, 4, 16, 0.45);
+  box-shadow: 0 14px 32px color-mix(
+      in srgb,
+      var(--surface-color) 40%,
+      transparent
+    );
 }
 
 .button--surface:focus-visible {
@@ -223,7 +313,12 @@ button,
     var(--color-accent) 35%,
     var(--color-border-subtle)
   );
-  box-shadow: 0 14px 32px rgba(12, 4, 16, 0.45), var(--focus-ring);
+  box-shadow: 0 14px 32px color-mix(
+        in srgb,
+        var(--surface-color) 40%,
+        transparent
+      ),
+    var(--focus-ring);
 }
 
 .button--ghost {
@@ -237,14 +332,70 @@ button,
   background: color-mix(in srgb, var(--color-accent) 16%, transparent);
   border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
   color: var(--color-heading);
-  box-shadow: 0 12px 28px rgba(255, 63, 94, 0.25);
+  box-shadow: 0 12px 28px var(--accent-shadow-soft);
 }
 
 .button--ghost:focus-visible {
   background: color-mix(in srgb, var(--color-accent) 16%, transparent);
   border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
   color: var(--color-heading);
-  box-shadow: 0 12px 28px rgba(255, 63, 94, 0.25), var(--focus-ring);
+  box-shadow: 0 12px 28px var(--accent-shadow-soft), var(--focus-ring);
+}
+
+.theme-toggle {
+  text-transform: none;
+  letter-spacing: 0.01em;
+  gap: 0.6rem;
+  min-height: 2.5rem;
+  font-size: 0.9rem;
+}
+
+.theme-toggle__icon,
+.theme-toggle__label {
+  display: none;
+}
+
+.theme-toggle__icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.theme-toggle__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.theme-toggle__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.theme-toggle--compact {
+  gap: 0.35rem;
+  padding-block: 0.4rem;
+  padding-inline: 0.35rem;
+}
+
+.theme-toggle--compact .theme-toggle__label {
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+:root[data-theme-preference="system"] .theme-toggle__icon--system,
+:root[data-theme-preference="system"] .theme-toggle__label--system {
+  display: inline-flex;
+}
+
+:root[data-theme-preference="light"] .theme-toggle__icon--light,
+:root[data-theme-preference="light"] .theme-toggle__label--light {
+  display: inline-flex;
+}
+
+:root[data-theme-preference="dark"] .theme-toggle__icon--dark,
+:root[data-theme-preference="dark"] .theme-toggle__label--dark {
+  display: inline-flex;
 }
 
 .app-bar {
@@ -373,7 +524,7 @@ button,
   text-transform: none;
   color: var(--color-muted-strong);
   background: color-mix(in srgb, var(--surface-raised) 78%, transparent);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border-subtle);
   transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease,
     color 0.2s ease, border-color 0.2s ease;
   cursor: pointer;
@@ -391,18 +542,30 @@ button,
   border-color: color-mix(
     in srgb,
     var(--color-accent) 25%,
-    rgba(255, 255, 255, 0.12)
+    var(--border-elevated)
   );
-  box-shadow: 0 12px 28px rgba(255, 71, 97, 0.28);
+  box-shadow: 0 12px 28px var(--accent-shadow-soft);
   outline: none;
 }
 
 .bottom-nav__item--active,
 .bottom-nav__item.is-active {
-  background: linear-gradient(135deg, var(--color-accent) 0%, #ff6b82 100%);
-  border-color: rgba(255, 255, 255, 0.18);
-  color: #16040a;
-  box-shadow: 0 14px 30px rgba(255, 71, 97, 0.35);
+  background: linear-gradient(
+    135deg,
+    color-mix(
+      in srgb,
+      var(--color-accent) 96%,
+      var(--color-background) 4%
+    ) 0%,
+    color-mix(
+      in srgb,
+      var(--color-accent) 90%,
+      var(--color-background) 10%
+    ) 100%
+  );
+  border-color: var(--border-elevated-strong);
+  color: var(--color-on-accent);
+  box-shadow: 0 14px 30px var(--accent-shadow-strong);
 }
 
 .bottom-nav__icon {
@@ -420,7 +583,7 @@ button,
 }
 
 .tab-nav::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
+  background: color-mix(in srgb, var(--color-heading) 22%, transparent);
   border-radius: var(--radius-lg);
 }
 
@@ -436,7 +599,7 @@ button,
   font-size: 0.95rem;
   color: var(--color-heading);
   background: color-mix(in srgb, var(--surface-raised) 70%, transparent);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--color-border-subtle);
   scroll-snap-align: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
@@ -444,7 +607,7 @@ button,
 .tab-nav a:hover,
 .tab-nav a:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 12px 30px rgba(255, 71, 97, 0.25);
+  box-shadow: 0 12px 30px var(--accent-shadow-soft);
   background: color-mix(
     in srgb,
     var(--color-accent) 20%,
@@ -453,10 +616,22 @@ button,
 }
 
 .tab-nav a[aria-current="page"] {
-  background: linear-gradient(135deg, var(--color-accent) 0%, #ff6b82 100%);
-  border-color: rgba(255, 255, 255, 0.18);
-  color: #12030b;
-  box-shadow: 0 14px 34px rgba(255, 71, 97, 0.4);
+  background: linear-gradient(
+    135deg,
+    color-mix(
+      in srgb,
+      var(--color-accent) 96%,
+      var(--color-background) 4%
+    ) 0%,
+    color-mix(
+      in srgb,
+      var(--color-accent) 90%,
+      var(--color-background) 10%
+    ) 100%
+  );
+  border-color: var(--border-elevated-strong);
+  color: var(--color-on-accent);
+  box-shadow: 0 14px 34px var(--accent-shadow-strong);
 }
 
 .page-shell {
@@ -523,10 +698,10 @@ button,
   text-transform: uppercase;
   background: linear-gradient(
     135deg,
-    rgba(255, 63, 94, 0.18),
-    rgba(255, 83, 108, 0.28)
+    color-mix(in srgb, var(--color-accent) 18%, transparent),
+    color-mix(in srgb, var(--color-accent) 30%, transparent)
   );
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-elevated);
   color: var(--color-heading);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
@@ -534,11 +709,11 @@ button,
 .filter-trigger:hover,
 .filter-trigger:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px rgba(255, 71, 97, 0.2);
+  box-shadow: 0 12px 28px var(--accent-shadow-soft);
   background: linear-gradient(
     135deg,
-    rgba(255, 63, 94, 0.28),
-    rgba(255, 83, 108, 0.38)
+    color-mix(in srgb, var(--color-accent) 28%, transparent),
+    color-mix(in srgb, var(--color-accent) 42%, transparent)
   );
 }
 
@@ -546,7 +721,7 @@ select,
 input,
 textarea {
   background: color-mix(in srgb, var(--surface-raised) 82%, transparent);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 0.85rem;
   color: var(--color-text);
   padding: 0.65rem 0.85rem;
@@ -558,7 +733,7 @@ select:focus,
 input:focus,
 textarea:focus {
   outline: none;
-  border-color: color-mix(in srgb, var(--color-accent) 50%, white 20%);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
   box-shadow: var(--focus-ring);
 }
 
@@ -586,7 +761,7 @@ textarea:focus {
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--surface-panel) 88%, transparent);
   border: 1px solid
-    color-mix(in srgb, var(--color-accent) 16%, rgba(255, 255, 255, 0.08));
+    color-mix(in srgb, var(--color-accent) 16%, var(--color-border-subtle));
   box-shadow: var(--shadow-soft);
   transition: transform 0.2s ease, box-shadow 0.2s ease,
     border-color 0.2s ease;
@@ -599,7 +774,11 @@ textarea:focus {
 }
 
 .resource-card[data-favorite="true"] {
-  border-color: color-mix(in srgb, var(--color-accent) 55%, rgba(255, 255, 255, 0.2));
+  border-color: color-mix(
+    in srgb,
+    var(--color-accent) 55%,
+    var(--border-elevated-strong)
+  );
   box-shadow: var(--shadow-hard),
     0 0 0 1px color-mix(in srgb, var(--color-accent) 35%, transparent),
     0 0 22px color-mix(in srgb, var(--color-accent) 25%, transparent);
@@ -642,8 +821,12 @@ textarea:focus {
   block-size: 2.5rem;
   border-radius: var(--radius-pill);
   border: 1px solid color-mix(in srgb, var(--color-accent) 18%, transparent);
-  background: color-mix(in srgb, var(--surface-panel) 82%, black 18%);
-  color: color-mix(in srgb, var(--color-muted) 85%, black 15%);
+  background: color-mix(
+    in srgb,
+    var(--surface-panel) 82%,
+    var(--color-background) 18%
+  );
+  color: color-mix(in srgb, var(--color-muted) 85%, var(--color-background) 15%);
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
     transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -653,7 +836,11 @@ textarea:focus {
   border-color: color-mix(in srgb, var(--color-accent) 40%, transparent);
   color: color-mix(in srgb, var(--color-accent) 70%, white 30%);
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(15, 6, 18, 0.3);
+  box-shadow: 0 8px 18px color-mix(
+      in srgb,
+      var(--surface-color) 38%,
+      transparent
+    );
 }
 
 .favorite-toggle__button:active {
@@ -774,7 +961,7 @@ textarea:focus {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  background: rgba(255, 255, 255, 0.06);
+  background: color-mix(in srgb, var(--color-text) 12%, transparent);
   color: var(--color-muted-strong);
 }
 
@@ -783,7 +970,7 @@ textarea:focus {
   border-radius: var(--radius-lg);
   padding: clamp(1.5rem, 5vw, 3rem);
   border: 1px solid
-    color-mix(in srgb, var(--color-accent) 18%, rgba(255, 255, 255, 0.08));
+    color-mix(in srgb, var(--color-accent) 18%, var(--color-border-subtle));
   box-shadow: var(--shadow-hard);
   display: grid;
   gap: clamp(1.5rem, 4vw, 2.5rem);
@@ -814,7 +1001,7 @@ textarea:focus {
 .content-body {
   display: grid;
   gap: 1rem;
-  color: color-mix(in srgb, var(--color-text) 88%, black 12%);
+  color: color-mix(in srgb, var(--color-text) 88%, var(--color-background) 12%);
 }
 
 .content-body p {
@@ -830,7 +1017,7 @@ textarea:focus {
   background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
   border-radius: var(--radius-lg);
   padding: clamp(1.75rem, 5vw, 3rem);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--color-border-subtle);
   box-shadow: var(--shadow-hard);
   overflow: hidden;
 }
@@ -842,12 +1029,12 @@ textarea:focus {
   pointer-events: none;
   background: radial-gradient(
       160% 160% at 0% 0%,
-      rgba(255, 71, 97, 0.2),
+      color-mix(in srgb, var(--color-accent) 24%, transparent),
       transparent 60%
     ),
     radial-gradient(
       120% 140% at 100% 10%,
-      rgba(255, 83, 108, 0.12),
+      color-mix(in srgb, var(--color-accent) 18%, transparent),
       transparent 60%
     );
   mix-blend-mode: screen;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,10 +1,12 @@
 ---
 import favoritesClientScript from "../scripts/favorites.client.ts?url";
+import themeClientScript from "../scripts/theme.client.ts?url";
 
 const {
   title = "Improv Toolbox",
   description = "Exercises, warmups, forms, and show tools.",
-  themeColor = "#0f172a",
+  themeColor = "#050b19",
+  lightThemeColor = "#ecfeff",
 } = Astro.props;
 const navLinks = [
   {
@@ -44,14 +46,19 @@ const isActive = (href: string) =>
   href === "/" ? currentPath === "/" : currentPath.startsWith(href);
 ---
 
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="dark" data-theme-preference="system">
   <head>
     <meta charset="utf-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
-    <meta name="theme-color" content={themeColor} />
+    <meta
+      name="theme-color"
+      content={themeColor}
+      data-theme-color-dark={themeColor}
+      data-theme-color-light={lightThemeColor}
+    />
     <title>{title}</title>
     <meta name="description" content={description} />
 
@@ -61,6 +68,46 @@ const isActive = (href: string) =>
       href="https://fonts.googleapis.com/css2?family=Epilogue:wght@600;700&family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+
+    <script>
+      (() => {
+        const storageKey = "improv-toolbox-theme";
+        const root = document.documentElement;
+        const readStoredPreference = () => {
+          try {
+            const value = window.localStorage.getItem(storageKey);
+            return value === "light" || value === "dark" || value === "system"
+              ? value
+              : null;
+          } catch {
+            return null;
+          }
+        };
+        const storedPreference = readStoredPreference();
+        const systemPrefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)"
+        ).matches;
+        const preference = storedPreference ?? "system";
+        const resolved =
+          preference === "dark" ||
+          (preference === "system" && systemPrefersDark)
+            ? "dark"
+            : "light";
+        root.dataset.themePreference = preference;
+        root.dataset.theme = resolved;
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+          const dataset = meta.dataset;
+          const nextColor =
+            resolved === "dark"
+              ? dataset.themeColorDark || meta.getAttribute("content")
+              : dataset.themeColorLight || meta.getAttribute("content");
+          if (nextColor) {
+            meta.setAttribute("content", nextColor);
+          }
+        }
+      })();
+    </script>
 
     <link rel="stylesheet" href="/styles/theme.css" />
     <link rel="stylesheet" href="/styles/every.css" />
@@ -81,6 +128,79 @@ const isActive = (href: string) =>
           </div>
         </div>
         <div class="app-bar__actions">
+          <button
+            class="button button--surface theme-toggle"
+            type="button"
+            data-theme-toggle
+            aria-label="Toggle theme"
+          >
+            <span
+              class="theme-toggle__icon theme-toggle__icon--system"
+              aria-hidden="true"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="4" y="5" width="16" height="12" rx="2" />
+                <path d="M9 19h6" />
+              </svg>
+            </span>
+            <span
+              class="theme-toggle__icon theme-toggle__icon--light"
+              aria-hidden="true"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="4" />
+                <path
+                  d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364-1.414 1.414M7.05 16.95l-1.414 1.414m12.728 0-1.414-1.414M7.05 7.05 5.636 5.636"
+                />
+              </svg>
+            </span>
+            <span
+              class="theme-toggle__icon theme-toggle__icon--dark"
+              aria-hidden="true"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"
+                />
+              </svg>
+            </span>
+            <span class="theme-toggle__label theme-toggle__label--system">
+              System
+            </span>
+            <span class="theme-toggle__label theme-toggle__label--light">
+              Light
+            </span>
+            <span class="theme-toggle__label theme-toggle__label--dark">
+              Dark
+            </span>
+          </button>
           <a class="app-cta" href="/tools/timer">Quick timer</a>
         </div>
       </div>
@@ -118,12 +238,86 @@ const isActive = (href: string) =>
           </a>
         ))
       }
+      <button
+        type="button"
+        class="bottom-nav__item theme-toggle theme-toggle--compact"
+        data-theme-toggle
+        aria-label="Toggle theme"
+      >
+        <span
+          class="theme-toggle__icon theme-toggle__icon--system"
+          aria-hidden="true"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="4" y="5" width="16" height="12" rx="2" />
+            <path d="M9 19h6" />
+          </svg>
+        </span>
+        <span
+          class="theme-toggle__icon theme-toggle__icon--light"
+          aria-hidden="true"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path
+              d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364-1.414 1.414M7.05 16.95l-1.414 1.414m12.728 0-1.414-1.414M7.05 7.05 5.636 5.636"
+            />
+          </svg>
+        </span>
+        <span
+          class="theme-toggle__icon theme-toggle__icon--dark"
+          aria-hidden="true"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path
+              d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"
+            />
+          </svg>
+        </span>
+        <span class="bottom-nav__label theme-toggle__label theme-toggle__label--system">
+          System
+        </span>
+        <span class="bottom-nav__label theme-toggle__label theme-toggle__label--light">
+          Light
+        </span>
+        <span class="bottom-nav__label theme-toggle__label theme-toggle__label--dark">
+          Dark
+        </span>
+      </button>
     </nav>
     <footer class="site-footer">
       <small>© {currentYear} Improv Toolbox Collective</small>
     </footer>
 
     <script type="module" src={favoritesClientScript}></script>
+    <script type="module" src={themeClientScript}></script>
 
     <script>
       (() => {

--- a/src/scripts/theme.client.ts
+++ b/src/scripts/theme.client.ts
@@ -1,0 +1,128 @@
+const STORAGE_KEY = "improv-toolbox-theme" as const;
+const CYCLE_ORDER = ["system", "light", "dark"] as const;
+type ThemePreference = (typeof CYCLE_ORDER)[number];
+
+const PREFERENCE_LABEL: Record<ThemePreference, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark",
+};
+
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+const root = document.documentElement;
+const themeMeta = document.querySelector(
+  'meta[name="theme-color"]'
+) as HTMLMetaElement | null;
+const metaThemeColors: Record<"light" | "dark", string> = {
+  light: themeMeta?.dataset.themeColorLight ?? "#eef1ff",
+  dark: themeMeta?.dataset.themeColorDark ?? "#050b19",
+};
+const toggleButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle]")
+);
+
+let activePreference: ThemePreference = getInitialPreference();
+applyPreference(activePreference, { persist: hasStoredPreference() });
+
+const handleMediaChange = () => {
+  if (activePreference === "system") {
+    applyPreference("system", { persist: false });
+  }
+};
+
+if (typeof prefersDark.addEventListener === "function") {
+  prefersDark.addEventListener("change", handleMediaChange);
+} else if (typeof prefersDark.addListener === "function") {
+  prefersDark.addListener(handleMediaChange);
+}
+
+toggleButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const next = getNextPreference(activePreference);
+    applyPreference(next);
+  });
+});
+
+function applyPreference(
+  preference: ThemePreference,
+  { persist = true }: { persist?: boolean } = {}
+) {
+  activePreference = preference;
+  const resolved = resolvePreference(preference);
+
+  root.dataset.themePreference = preference;
+  root.dataset.theme = resolved;
+  updateMetaColor(resolved);
+  updateToggleLabels(preference);
+
+  if (persist) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, preference);
+    } catch {
+      /* no-op */
+    }
+  }
+}
+
+function getInitialPreference(): ThemePreference {
+  const stored = readStoredPreference();
+  if (stored) {
+    return stored;
+  }
+
+  const attr = root.dataset.themePreference;
+  if (isThemePreference(attr)) {
+    return attr;
+  }
+
+  return "system";
+}
+
+function hasStoredPreference(): boolean {
+  return Boolean(readStoredPreference());
+}
+
+function readStoredPreference(): ThemePreference | null {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (isThemePreference(stored)) {
+      return stored;
+    }
+  } catch {
+    /* ignored */
+  }
+  return null;
+}
+
+function resolvePreference(pref: ThemePreference): "light" | "dark" {
+  if (pref === "system") {
+    return prefersDark.matches ? "dark" : "light";
+  }
+  return pref;
+}
+
+function getNextPreference(current: ThemePreference): ThemePreference {
+  const index = CYCLE_ORDER.indexOf(current);
+  const nextIndex = (index + 1) % CYCLE_ORDER.length;
+  return CYCLE_ORDER[nextIndex];
+}
+
+function updateMetaColor(theme: "light" | "dark") {
+  if (!themeMeta) return;
+  themeMeta.content = metaThemeColors[theme];
+}
+
+function updateToggleLabels(preference: ThemePreference) {
+  const currentLabel = PREFERENCE_LABEL[preference];
+  const nextLabel = PREFERENCE_LABEL[getNextPreference(preference)];
+  toggleButtons.forEach((button) => {
+    button.setAttribute(
+      "aria-label",
+      `Theme: ${currentLabel}. Activate to switch to ${nextLabel} mode.`
+    );
+  });
+}
+
+function isThemePreference(value: unknown): value is ThemePreference {
+  return CYCLE_ORDER.includes(value as ThemePreference);
+}

--- a/src/scripts/theme.client.ts
+++ b/src/scripts/theme.client.ts
@@ -102,9 +102,13 @@ function resolvePreference(pref: ThemePreference): "light" | "dark" {
 }
 
 function getNextPreference(current: ThemePreference): ThemePreference {
-  const index = CYCLE_ORDER.indexOf(current);
-  const nextIndex = (index + 1) % CYCLE_ORDER.length;
-  return CYCLE_ORDER[nextIndex];
+  if (current === "system") {
+    return prefersDark.matches ? "light" : "dark";
+  }
+  if (current === "light") {
+    return "dark";
+  }
+  return "system";
 }
 
 function updateMetaColor(theme: "light" | "dark") {

--- a/tests/site.test.mjs
+++ b/tests/site.test.mjs
@@ -68,9 +68,18 @@ test('drawer navigation exposes primary sections', () => {
 });
 
 test('home page sets theme color meta', () => {
-  const themeMeta = homeHtml.match(/<meta name="theme-color" content="([^"]+)">/);
+  const themeMeta = homeHtml.match(
+    /<meta name="theme-color" content="([^"]+)"([^>]*)>/
+  );
   assert.ok(themeMeta, 'theme-color meta tag is missing');
-  assert.strictEqual(themeMeta[1], '#0f172a');
+  assert.strictEqual(themeMeta[1], '#050b19');
+  if (themeMeta[2]) {
+    assert.match(
+      themeMeta[2],
+      /data-theme-color-light="#ecfeff"/,
+      'light theme color data attribute missing'
+    );
+  }
 });
 
 test('home page features category previews', () => {

--- a/tests/theme-contrast.test.mjs
+++ b/tests/theme-contrast.test.mjs
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const MIN_CONTRAST = 4.5;
+
+const srgbChannel = (value) => {
+  return value <= 0.04045
+    ? value / 12.92
+    : Math.pow((value + 0.055) / 1.055, 2.4);
+};
+
+const toLinear = (component) => srgbChannel(component / 255);
+
+const fromLinear = (value) => {
+  if (value <= 0.0031308) {
+    return Math.round(value * 12.92 * 255);
+  }
+  return Math.round((1.055 * Math.pow(value, 1 / 2.4) - 0.055) * 255);
+};
+
+const hexToRgb = (hex) => {
+  const clean = hex.replace('#', '');
+  return [0, 2, 4].map((offset) => parseInt(clean.slice(offset, offset + 2), 16));
+};
+
+const rgbToHex = (rgb) =>
+  `#${rgb
+    .map((component) => component.toString(16).padStart(2, '0'))
+    .join('')}`;
+
+const mix = (colorA, colorB, percentA) => {
+  const ratioA = percentA / 100;
+  const ratioB = 1 - ratioA;
+  const linearA = hexToRgb(colorA).map(toLinear);
+  const linearB = hexToRgb(colorB).map(toLinear);
+  const mixed = linearA.map((value, index) => value * ratioA + linearB[index] * ratioB);
+  return rgbToHex(mixed.map(fromLinear));
+};
+
+const luminance = (hex) => {
+  const [r, g, b] = hexToRgb(hex).map((component) => component / 255);
+  const [lr, lg, lb] = [r, g, b].map(srgbChannel);
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+};
+
+const contrast = (fg, bg) => {
+  const [L1, L2] = [luminance(fg), luminance(bg)].sort((a, b) => b - a);
+  return (L1 + 0.05) / (L2 + 0.05);
+};
+
+const themes = {
+  light: {
+    background: '#ecfeff',
+    text: '#1f2937',
+    accent: '#0f4c81',
+    accentSoft: '#1d6fb8',
+    onAccent: '#f8f9ff',
+    link: '#1d6fb8',
+    linkHover: '#0f4c81',
+    muted: mix('#1f2937', '#ecfeff', 85),
+    mutedStrong: mix('#1f2937', '#ecfeff', 92),
+    accentSurfaceStart: mix('#0f4c81', '#ecfeff', 92),
+    accentSurfaceHighlight: mix('#0f4c81', '#ecfeff', 96),
+    accentSurfaceEnd: '#0f4c81',
+    accentSurfaceMid: mix('#0f4c81', '#ecfeff', 90),
+  },
+  dark: {
+    background: '#050b19',
+    text: '#e2e8f0',
+    accent: '#0f6abf',
+    accentSoft: '#4cc4ff',
+    onAccent: '#f8fafc',
+    link: '#4cc4ff',
+    linkHover: '#78d0ff',
+    muted: mix('#94a3b8', '#ffffff', 78),
+    mutedStrong: mix('#bae6fd', '#ffffff', 68),
+    accentSurfaceStart: mix('#0f6abf', '#050b19', 92),
+    accentSurfaceHighlight: mix('#0f6abf', '#050b19', 96),
+    accentSurfaceEnd: '#0f6abf',
+    accentSurfaceMid: mix('#0f6abf', '#050b19', 90),
+  },
+};
+
+const ensureContrast = (description, fg, bg, minimum = MIN_CONTRAST) => {
+  const ratio = contrast(fg, bg);
+  assert.ok(
+    ratio >= minimum,
+    `${description} contrast ${ratio.toFixed(2)} fell below ${minimum}`,
+  );
+};
+
+test('light theme tokens maintain readable contrast', () => {
+  const theme = themes.light;
+  ensureContrast('body text', theme.text, theme.background);
+  ensureContrast('muted text', theme.muted, theme.background);
+  ensureContrast('strong muted text', theme.mutedStrong, theme.background);
+  ensureContrast('link text', theme.link, theme.background);
+  ensureContrast('link hover', theme.linkHover, theme.background);
+  ensureContrast('accent surface start', theme.onAccent, theme.accentSurfaceStart);
+  ensureContrast('accent surface highlight', theme.onAccent, theme.accentSurfaceHighlight);
+  ensureContrast('accent surface end', theme.onAccent, theme.accentSurfaceEnd);
+  ensureContrast('accent surface mid', theme.onAccent, theme.accentSurfaceMid);
+});
+
+test('dark theme tokens maintain readable contrast', () => {
+  const theme = themes.dark;
+  ensureContrast('body text', theme.text, theme.background);
+  ensureContrast('muted text', theme.muted, theme.background);
+  ensureContrast('strong muted text', theme.mutedStrong, theme.background);
+  ensureContrast('link text', theme.link, theme.background);
+  ensureContrast('link hover', theme.linkHover, theme.background);
+  ensureContrast('accent surface start', theme.onAccent, theme.accentSurfaceStart);
+  ensureContrast('accent surface highlight', theme.onAccent, theme.accentSurfaceHighlight);
+  ensureContrast('accent surface end', theme.onAccent, theme.accentSurfaceEnd);
+  ensureContrast('accent surface mid', theme.onAccent, theme.accentSurfaceMid);
+});


### PR DESCRIPTION
## Summary
- tighten the light and dark theme palettes so link, muted, and accent tokens meet WCAG contrast targets
- retune accent gradients to mix with the active background tones for readable on-accent labels
- add automated contrast regression tests that cover both themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dadc967dd0832a9f321a5d4c5d1b9b