### PR TITLE
Improve service worker asset caching

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -114,6 +114,7 @@ Types:
 ## 6. Non-Functional Requirements
 
 - **Performance**: Optimized for mobile, low bandwidth, and offline use
+  - The service worker pre-caches the app shell, theme stylesheet, and hashed Astro bundles so the UI and styling remain available offline after installation.
 - **Usability**: Clean UI with minimal distractions
 - **Accessibility**: WCAG AA compliance where possible
 - **Extensibility**: Easy for contributors to add new tools/content by following front matter schema

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,27 +1,100 @@
-const CACHE = "toolbox-v1";
-const ASSETS = [
-  "/", "/styles/every.css", "/manifest.webmanifest",
-  "/icons/icon-192.png", "/icons/icon-512.png"
+const CACHE = "toolbox-v2";
+const CORE_ASSETS = [
+  "/styles/every.css",
+  "/styles/theme.css",
+  "/manifest.webmanifest",
+  "/icons/icon-192.png",
+  "/icons/icon-512.png"
 ];
+const SHELL_URL = "/";
+const ASTRO_BUNDLE_REGEX = /["'](\/_astro\/[^"']+\.(?:css|js))(?:\?[^"']*)?["']/g;
 
-self.addEventListener("install", e => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
-});
+function shouldCache(request, response) {
+  return (
+    request.url.startsWith(self.location.origin) &&
+    response &&
+    response.ok &&
+    ["style", "script", "font"].includes(request.destination)
+  );
+}
 
-self.addEventListener("activate", e => {
-  e.waitUntil(caches.keys().then(keys =>
-    Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-  ));
-});
+async function precacheShell(cache) {
+  try {
+    const response = await fetch(SHELL_URL, { cache: "no-cache" });
+    if (!response || !response.ok) return;
 
-self.addEventListener("fetch", e => {
-  const { request } = e;
-  // network-first for html, cache-first for others
-  if (request.mode === "navigate") {
-    e.respondWith(fetch(request).catch(() => caches.match("/")));
-  } else {
-    e.respondWith(
-      caches.match(request).then(res => res || fetch(request))
+    await cache.put(SHELL_URL, response.clone());
+    const html = await response.text();
+    const bundleUrls = new Set();
+    let match;
+    while ((match = ASTRO_BUNDLE_REGEX.exec(html)) !== null) {
+      bundleUrls.add(match[1]);
+    }
+    if (bundleUrls.size === 0) return;
+    await Promise.all(
+      Array.from(bundleUrls, url => cache.add(url).catch(err => console.warn(`Failed to cache ${url}`, err)))
     );
+  } catch (err) {
+    console.warn("Service worker failed to precache shell assets", err);
   }
+}
+
+self.addEventListener("install", event => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE);
+    await cache.addAll(CORE_ASSETS);
+    await precacheShell(cache);
+  })());
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", event => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener("fetch", event => {
+  const { request } = event;
+  if (request.method !== "GET") {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      (async () => {
+        try {
+          const response = await fetch(request);
+          if (response && response.ok) {
+            const cache = await caches.open(CACHE);
+            cache.put(request, response.clone());
+          }
+          return response;
+        } catch (err) {
+          const cached = await caches.match(request);
+          return cached || caches.match(SHELL_URL);
+        }
+      })()
+    );
+    return;
+  }
+
+  const respondFromNetwork = async () => {
+    try {
+      const response = await fetch(request);
+      if (shouldCache(request, response)) {
+        const cache = await caches.open(CACHE);
+        cache.put(request, response.clone());
+      }
+      return response;
+    } catch (err) {
+      const cached = await caches.match(request);
+      if (cached) return cached;
+      throw err;
+    }
+  };
+
+  event.respondWith(caches.match(request).then(cached => cached || respondFromNetwork()));
 });


### PR DESCRIPTION
## Summary
- extend the service worker to cache the theme stylesheet and Astro bundles alongside the app shell
- add safer fetch handling, cache clean-up, and navigation fallbacks while bumping the toolbox cache version
- document the offline styling guarantee in the requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbcd2b3d34832ab1ac8669a3283cc1