### PR TITLE
Reuse existing icon for PWA shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Improv Toolbox is a mobile-first Progressive Web App (PWA) for improv teachers a
 - **Personal notes** panels on every detail page so coaches can jot Markdown snippets per item ([NotesPanel](src/components/NotesPanel.astro)).
 - **Lesson Planner tool** for sequencing warmups, exercises, and breaks into reusable sessions ([lesson plans](src/pages/tools/lesson-plans/index.astro)).
 - **PWA shell** that ships a dark theme, offline-friendly build, and install prompts for mobile devices.
+- **Mobile quick actions** that surface shortcuts to the Timer, Warmups, and Exercises right from the home screen.
 
 ## Getting Started
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -43,6 +43,7 @@ All content sections (warmups, exercises, forms, tools) share the same **base fe
   - Static content collections with list filtering, detail pages, favourites, and tool embeds for exercises, warmups, and forms (see [exercises index](../src/pages/exercises/index.astro)).
   - Personal notes saved per item with offline storage handled by [NotesPanel](../src/components/NotesPanel.astro).
   - Tools directory with Timer, Gauss Timer, Jam Groupaliser, Suggestion Generator, and the [Lesson Planner](../src/pages/tools/lesson-plans/index.astro).
+  - Installed PWAs expose home screen quick actions for Timer, Warmups, and Exercises via manifest shortcuts.
 - **In progress:** Enhancing forms-specific filters and deep-link coverage for suggestion APIs.
 - **Planned (backlog):** User submissions, advanced search, cross-device sync, and scheduling workflows.
 
@@ -129,6 +130,7 @@ Types:
 
 ## Change Log
 
+- **2025-10-15:** Documented PWA quick actions that deep link to Timer, Warmups, and Exercises.
 - **2025-10-14:** Added single-word `purpose`, `tags`, `source`, and `credit` requirements for exercises and captured Cliffweb import metadata expectations.
 - **2025-10-12:** Documented delivered favourites, personal notes, and Lesson Planner functionality; refreshed future roadmap items.
 - **2025-10-05:** Captured alpha scope (navigation, content collections, tools) and documented automated HTML regression tests.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -7,6 +7,10 @@
 - Review generated descriptions for edge cases where HTML lists or emphasis lost fidelity.
 - Capture any manual corrections needed so the Python importer can be iterated instead of hand-editing.
 
+### Inline shortcut icon once bespoke asset ready
+
+- Generate a dedicated 96×96 shortcut icon and embed it as a base64 `data:` URL in `public/manifest.webmanifest` so the PWA can expose tailor-made artwork without adding new binary assets to the repo.
+
 ## Refactor opportunities
 
 ### Modularize NotesPanel data and rendering helpers

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -8,5 +8,34 @@
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "shortcuts": [
+    {
+      "name": "Timer",
+      "short_name": "Timer",
+      "description": "Jump straight into the rehearsal countdown timer.",
+      "url": "/tools/timer",
+      "icons": [
+        { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }
+      ]
+    },
+    {
+      "name": "Warmups",
+      "short_name": "Warmups",
+      "description": "Browse warmups to kick off a rehearsal fast.",
+      "url": "/warmups",
+      "icons": [
+        { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }
+      ]
+    },
+    {
+      "name": "Exercises",
+      "short_name": "Exercises",
+      "description": "Open the drills library for coaching sessions.",
+      "url": "/exercises",
+      "icons": [
+        { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- reuse the existing 192px application icon for the PWA shortcuts instead of introducing a new binary asset
- document a follow-up task to inline a bespoke 96px base64 icon in the manifest when available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbcd2f90a0832abb6d8fc3351518d1