### PR TITLE
Add fuzzy resource search and improve filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Improv Toolbox is a mobile-first Progressive Web App (PWA) for improv teachers a
 - **Main navigation drawer** with instant access to Home, Exercises, Forms, Warmups, and Tools.
 - **Landing page** hero cards that preview every collection and highlight sample content.
 - **Tools directory** with dedicated pages for Timer, Gauss Timer, Jam Groupaliser, and Suggestion Generator.
-- **Exercises, forms, and warmups** content collections with filter drawers, rich metadata, and generated detail pages.
+- **Exercises, forms, and warmups** content collections with weighted fuzzy search, structured filters, rich metadata, and generated detail pages.
 - **Favorites filters** so recurring go-to items surface quickly across the listings ([exercises index](src/pages/exercises/index.astro)).
 - **Personal notes** panels on every detail page so coaches can jot Markdown snippets per item ([NotesPanel](src/components/NotesPanel.astro)).
 - **Lesson Planner tool** for sequencing warmups, exercises, and breaks into reusable sessions ([lesson plans](src/pages/tools/lesson-plans/index.astro)).

--- a/docs/outline.md
+++ b/docs/outline.md
@@ -24,7 +24,7 @@ Shipped capabilities already cover lesson planning, personal notes, and offline-
 
 Primary destinations (Home, Exercises, Forms, Warmups, Tools) sit in a mobile-first bottom navigation bar with icon + label pairings. The sticky top app bar hosts the title, quick timer shortcut, and a standard hamburger trigger that anchors the modal drawer. A persistent "Menu" action in the bottom bar opens the same drawer so overflow items stay reachable even after long scrolls.
 
-For the content sections the user can list, filter and view detail pages for each element. Favourites persist locally (via [`FavoriteToggle`](../src/components/FavoriteToggle.astro)) so facilitators can filter by their go-to items.
+For the content sections the user can list, filter and view detail pages for each element. Listings now apply weighted fuzzy search across titles, metadata, and descriptions, while favourites persist locally (via [`FavoriteToggle`](../src/components/FavoriteToggle.astro)) so facilitators can filter by their go-to items.
 
 When on a detail page, if there is a matching tool, it should be possible to run the tool directly from the page. For example, for an exercise with a thirty second stare start and then a one minute scene, there should be a timer that has a thirty second and then one minute timers. For an excersise about playing emotions, there should be a suggestion component, pre filtered to only select from a collection of emotions, same for whatever, like the seven deadly sins, only the seven sins should be possible suggestions. For a form like Gauss form, there should be a Gauss timer.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -40,7 +40,7 @@ All content sections (warmups, exercises, forms, tools) share the same **base fe
 
 - **Delivered (alpha):**
   - Global drawer navigation covering Home, Exercises, Forms, Warmups, and Tools.
-  - Static content collections with list filtering, detail pages, favourites, and tool embeds for exercises, warmups, and forms (see [exercises index](../src/pages/exercises/index.astro)).
+  - Static content collections with weighted fuzzy search, structured filters, detail pages, favourites, and tool embeds for exercises, warmups, and forms (see [exercises index](../src/pages/exercises/index.astro)).
   - Personal notes saved per item with offline storage handled by [NotesPanel](../src/components/NotesPanel.astro).
   - Tools directory with Timer, Gauss Timer, Jam Groupaliser, Suggestion Generator, and the [Lesson Planner](../src/pages/tools/lesson-plans/index.astro).
   - Installed PWAs expose home screen quick actions for Timer, Warmups, and Exercises via manifest shortcuts.
@@ -135,6 +135,7 @@ Types:
 
 - **2025-10-15:** Documented PWA quick actions that deep link to Timer, Warmups, and Exercises.
 - **2025-10-16:** Documented the streamlined standalone home experience for installed devices.
+- **2025-10-17:** Added weighted fuzzy search across resource listings and refreshed filter tooling.
 - **2025-10-14:** Added single-word `purpose`, `tags`, `source`, and `credit` requirements for exercises and captured Cliffweb import metadata expectations.
 - **2025-10-12:** Documented delivered favourites, personal notes, and Lesson Planner functionality; refreshed future roadmap items.
 - **2025-10-05:** Captured alpha scope (navigation, content collections, tools) and documented automated HTML regression tests.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,15 @@
 
 ## Tasks
 
+### Backfill interaction coverage for resource filters
+
+- Add automated browser tests that exercise the fuzzy search, structured filters, and favourites-only toggle across exercises, warmups, and forms.
+- Capture baseline expectations for ranking so future tweaks to the fuzzy weights stay intentional.
+
+### Evaluate swapping custom fuzzy index for Fuse.js
+
+- Now that the listings rely on a homegrown `FuzzyIndex`, audit bundle impact and browser support before replacing it with the upstream Fuse.js package once dependency installs are available.
+
 ### Polish Cliffweb exercise import formatting
 
 - Review generated descriptions for edge cases where HTML lists or emphasis lost fidelity.

--- a/src/components/FilterDrawer.astro
+++ b/src/components/FilterDrawer.astro
@@ -1,5 +1,18 @@
 ---
-const { fields = [], slot } = Astro.props;
+interface FilterField {
+  name: string;
+  label: string;
+  type: string;
+  options?: string[];
+  placeholder?: string;
+  inputMode?: string;
+  autocomplete?: string;
+}
+
+const { fields = [], slot } = Astro.props as {
+  fields?: FilterField[];
+  slot?: unknown;
+};
 ---
 
 <style>
@@ -113,7 +126,14 @@ const { fields = [], slot } = Astro.props;
                 ))}
               </select>
             ) : (
-              <input id={inputId} type={field.type} name={field.name} />
+              <input
+                id={inputId}
+                type={field.type}
+                name={field.name}
+                placeholder={field.placeholder}
+                inputmode={field.inputMode}
+                autocomplete={field.autocomplete}
+              />
             )}
           </label>
         );
@@ -154,6 +174,9 @@ const { fields = [], slot } = Astro.props;
   });
   backdrop?.addEventListener("click", closeDrawer);
   drawer?.querySelectorAll("input,select").forEach((el) => {
+    if (el instanceof HTMLInputElement && el.type === "search") {
+      return;
+    }
     el.addEventListener("change", () => {
       closeDrawer();
     });

--- a/src/pages/exercises/index.astro
+++ b/src/pages/exercises/index.astro
@@ -25,6 +25,25 @@ const minPeople = Array.from(
     value != null
   ))
 ).sort((a, b) => a - b);
+const exerciseResourceData = exercises.map((exercise) => ({
+  id: exercise.slug,
+  name: exercise.data.name,
+  focus: exercise.data.focus ?? "",
+  source: exercise.data.source ?? "",
+  credit: exercise.data.credit ?? "",
+  minimumPeople:
+    exercise.data.minimumPeople != null
+      ? String(exercise.data.minimumPeople)
+      : "",
+  description: exercise.data.shortDescription ?? "",
+  tags: Array.isArray(exercise.data.tags)
+    ? exercise.data.tags.filter(Boolean).join(" ")
+    : "",
+}));
+const exerciseResourceJson = JSON.stringify(exerciseResourceData).replace(
+  /</g,
+  "\\u003c"
+);
 ---
 
 <BaseLayout>
@@ -41,6 +60,13 @@ const minPeople = Array.from(
       <div class="collection__controls">
         <FilterDrawer
           fields={[
+            {
+              name: "query",
+              label: "Search",
+              type: "search",
+              placeholder: "Search exercises...",
+              autocomplete: "off",
+            },
             { name: "name", label: "Name", type: "select", options: names },
             focuses.length
               ? {
@@ -79,11 +105,17 @@ const minPeople = Array.from(
         />
       </div>
     </header>
+    <script
+      type="application/json"
+      data-resource-list="exerciseList"
+      set:html={exerciseResourceJson}
+    ></script>
     <ul id="exerciseList" class="resource-list">
       {
         exercises.map((exercise) => (
           <li
             class="resource-card"
+            data-resource-id={exercise.slug}
             data-name={exercise.data.name}
             data-focus={exercise.data.focus ?? ""}
             data-source={exercise.data.source ?? ""}

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -14,6 +14,19 @@ const names = Array.from(new Set(forms.map((f) => f.data.name))).sort((a, b) =>
 const types = Array.from(
   new Set(forms.map((f) => f.data.type).filter(Boolean))
 ).sort((a, b) => a.localeCompare(b));
+const formResourceData = forms.map((form) => ({
+  id: form.slug,
+  name: form.data.name,
+  type: form.data.type ?? "",
+  description: form.data.shortDescription ?? "",
+  tags: Array.isArray(form.data.tags)
+    ? form.data.tags.filter(Boolean).join(" ")
+    : "",
+}));
+const formResourceJson = JSON.stringify(formResourceData).replace(
+  /</g,
+  "\\u003c"
+);
 ---
 
 <BaseLayout>
@@ -30,6 +43,13 @@ const types = Array.from(
       <div class="collection__controls">
         <FilterDrawer
           fields={[
+            {
+              name: "query",
+              label: "Search",
+              type: "search",
+              placeholder: "Search forms...",
+              autocomplete: "off",
+            },
             { name: "name", label: "Name", type: "select", options: names },
             types.length
               ? { name: "type", label: "Type", type: "select", options: types }
@@ -39,11 +59,17 @@ const types = Array.from(
         />
       </div>
     </header>
+    <script
+      type="application/json"
+      data-resource-list="formList"
+      set:html={formResourceJson}
+    ></script>
     <ul id="formList" class="resource-list">
       {
         forms.map((form) => (
           <li
             class="resource-card"
+            data-resource-id={form.slug}
             data-name={form.data.name}
             data-type={form.data.type ?? ""}
             data-favorite="false"

--- a/src/pages/warmups/index.astro
+++ b/src/pages/warmups/index.astro
@@ -19,6 +19,23 @@ const minPeople = Array.from(
     value != null
   ))
 ).sort((a, b) => a - b);
+const warmupResourceData = warmups.map((warmup) => ({
+  id: warmup.slug,
+  name: warmup.data.name,
+  focus: warmup.data.focus ?? "",
+  minimumPeople:
+    warmup.data.minimumPeople != null
+      ? String(warmup.data.minimumPeople)
+      : "",
+  description: warmup.data.shortDescription ?? "",
+  tags: Array.isArray(warmup.data.tags)
+    ? warmup.data.tags.filter(Boolean).join(" ")
+    : "",
+}));
+const warmupResourceJson = JSON.stringify(warmupResourceData).replace(
+  /</g,
+  "\\u003c"
+);
 ---
 
 <BaseLayout>
@@ -34,6 +51,13 @@ const minPeople = Array.from(
       <div class="collection__controls">
         <FilterDrawer
           fields={[
+            {
+              name: "query",
+              label: "Search",
+              type: "search",
+              placeholder: "Search warmups...",
+              autocomplete: "off",
+            },
             { name: "name", label: "Name", type: "select", options: names },
             focuses.length
               ? {
@@ -56,11 +80,17 @@ const minPeople = Array.from(
         />
       </div>
     </header>
+    <script
+      type="application/json"
+      data-resource-list="warmupList"
+      set:html={warmupResourceJson}
+    ></script>
     <ul id="warmupList" class="resource-list">
       {
         warmups.map((warmup) => (
           <li
             class="resource-card"
+            data-resource-id={warmup.slug}
             data-name={warmup.data.name}
             data-focus={warmup.data.focus ?? ""}
             data-minimum-people={

--- a/src/scripts/exercises-list.client.ts
+++ b/src/scripts/exercises-list.client.ts
@@ -2,6 +2,19 @@ import { setupResourceListFiltering } from "../utils/resourceFilters";
 
 const OPTIONS = {
   listSelector: "#exerciseList",
+  searchField: "query",
+  fuzzyOptions: {
+    keys: [
+      { name: "name", weight: 0.45 },
+      { name: "focus", weight: 0.2 },
+      { name: "source", weight: 0.15 },
+      { name: "credit", weight: 0.1 },
+      { name: "description", weight: 0.3 },
+      { name: "tags", weight: 0.15 },
+    ],
+    threshold: 0.55,
+    minMatchCharLength: 2,
+  },
   equalityFilters: [
     { field: "name" },
     { field: "focus" },

--- a/src/scripts/forms-list.client.ts
+++ b/src/scripts/forms-list.client.ts
@@ -2,6 +2,17 @@ import { setupResourceListFiltering } from "../utils/resourceFilters";
 
 const OPTIONS = {
   listSelector: "#formList",
+  searchField: "query",
+  fuzzyOptions: {
+    keys: [
+      { name: "name", weight: 0.5 },
+      { name: "type", weight: 0.25 },
+      { name: "description", weight: 0.3 },
+      { name: "tags", weight: 0.15 },
+    ],
+    threshold: 0.55,
+    minMatchCharLength: 2,
+  },
   equalityFilters: [
     { field: "name" },
     { field: "type" },

--- a/src/scripts/warmups-list.client.ts
+++ b/src/scripts/warmups-list.client.ts
@@ -2,6 +2,18 @@ import { setupResourceListFiltering } from "../utils/resourceFilters";
 
 const OPTIONS = {
   listSelector: "#warmupList",
+  searchField: "query",
+  fuzzyOptions: {
+    keys: [
+      { name: "name", weight: 0.5 },
+      { name: "focus", weight: 0.25 },
+      { name: "description", weight: 0.3 },
+      { name: "tags", weight: 0.15 },
+      { name: "minimumPeople", weight: 0.1 },
+    ],
+    threshold: 0.55,
+    minMatchCharLength: 2,
+  },
   equalityFilters: [
     { field: "name" },
     { field: "focus" },

--- a/src/utils/fuzzySearch.ts
+++ b/src/utils/fuzzySearch.ts
@@ -1,0 +1,165 @@
+export interface FuzzyKeyOption {
+  name: string;
+  weight?: number;
+}
+
+export interface FuzzyIndexOptions {
+  keys: FuzzyKeyOption[];
+  /**
+   * Maximum normalized distance allowed between the query and a candidate.
+   * 0 means an exact match only, 1 allows any match. Defaults to 0.6.
+   */
+  threshold?: number;
+  /**
+   * Minimum query length required before fuzzy matching runs. Defaults to 2.
+   */
+  minMatchCharLength?: number;
+}
+
+export interface FuzzySearchResult<T> {
+  item: T;
+  refIndex: number;
+  score: number;
+}
+
+interface WeightedScore {
+  score: number;
+  weight: number;
+}
+
+function normalizeRecord(record: Record<string, string>): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    normalized[key] = value?.toString().trim() ?? "";
+  }
+  return normalized;
+}
+
+function normalizedDistance(a: string, b: string): number {
+  if (!a && !b) {
+    return 0;
+  }
+  if (!a || !b) {
+    return 1;
+  }
+  if (a === b) {
+    return 0;
+  }
+  const matrix: number[][] = [];
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+
+  for (let row = 0; row < rows; row += 1) {
+    matrix[row] = [row];
+  }
+
+  for (let col = 1; col < cols; col += 1) {
+    matrix[0][col] = col;
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let col = 1; col < cols; col += 1) {
+      if (a[row - 1] === b[col - 1]) {
+        matrix[row][col] = matrix[row - 1][col - 1];
+        continue;
+      }
+      const deletion = matrix[row - 1][col] + 1;
+      const insertion = matrix[row][col - 1] + 1;
+      const substitution = matrix[row - 1][col - 1] + 1;
+      matrix[row][col] = Math.min(deletion, insertion, substitution);
+    }
+  }
+
+  const distance = matrix[rows - 1][cols - 1];
+  const maxLength = Math.max(a.length, b.length, 1);
+  return distance / maxLength;
+}
+
+function tokenDistance(candidate: string, query: string): number {
+  const normalizedCandidate = candidate.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+
+  if (!normalizedCandidate) {
+    return 1;
+  }
+  if (normalizedCandidate.includes(normalizedQuery)) {
+    // Exact substring match — treat as best possible score.
+    return 0;
+  }
+
+  const tokens = normalizedCandidate.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+  if (!tokens.length) {
+    return normalizedDistance(normalizedCandidate, normalizedQuery);
+  }
+
+  let best = 1;
+  for (const token of tokens) {
+    const score = normalizedDistance(token, normalizedQuery);
+    if (score < best) {
+      best = score;
+      if (best === 0) {
+        break;
+      }
+    }
+  }
+  return best;
+}
+
+export class FuzzyIndex<T extends Record<string, string>> {
+  private readonly list: T[];
+
+  private readonly options: Required<Omit<FuzzyIndexOptions, "keys">> & { keys: FuzzyKeyOption[] };
+
+  constructor(list: T[], options: FuzzyIndexOptions) {
+    if (!options.keys?.length) {
+      throw new Error("FuzzyIndex requires at least one key");
+    }
+    this.list = list.map((item) => normalizeRecord(item));
+    this.options = {
+      keys: options.keys,
+      threshold: options.threshold ?? 0.6,
+      minMatchCharLength: options.minMatchCharLength ?? 2,
+    };
+  }
+
+  search(query: string): FuzzySearchResult<T>[] {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (normalizedQuery.length < this.options.minMatchCharLength) {
+      return [];
+    }
+
+    const results: FuzzySearchResult<T>[] = [];
+    this.list.forEach((item, index) => {
+      const scores: WeightedScore[] = [];
+
+      for (const keyOption of this.options.keys) {
+        const weight = keyOption.weight ?? 1;
+        const value = item[keyOption.name];
+        if (!value) {
+          continue;
+        }
+        const score = tokenDistance(value, normalizedQuery);
+        scores.push({ score, weight });
+      }
+
+      if (!scores.length) {
+        return;
+      }
+
+      const weightedScore =
+        scores.reduce((total, entry) => total + entry.score * entry.weight, 0) /
+        scores.reduce((total, entry) => total + entry.weight, 0);
+
+      if (weightedScore <= this.options.threshold) {
+        results.push({
+          item: item as T,
+          refIndex: index,
+          score: weightedScore,
+        });
+      }
+    });
+
+    results.sort((a, b) => a.score - b.score || a.refIndex - b.refIndex);
+    return results;
+  }
+}

--- a/src/utils/resourceFilters.ts
+++ b/src/utils/resourceFilters.ts
@@ -2,6 +2,7 @@ import {
   loadFavorites,
   subscribeToFavorites,
 } from "./favorites";
+import { FuzzyIndex, FuzzyIndexOptions } from "./fuzzySearch";
 
 interface EqualityFilterDefinition {
   field: string;
@@ -13,17 +14,119 @@ interface SetupResourceListFilteringOptions {
   formSelector?: string;
   favoritesField?: string;
   equalityFilters?: EqualityFilterDefinition[];
+  searchField?: string;
+  fuzzyOptions?: FuzzyIndexOptions;
 }
 
 type FavoritesState = Record<string, unknown>;
 
 type Nullable<T> = T | null | undefined;
 
+interface ResourceSearchEntry {
+  id: string;
+  [key: string]: string;
+}
+
+interface ResourceEntry {
+  id: string;
+  card: HTMLLIElement;
+  dataset: Record<string, string>;
+  searchable: Record<string, string>;
+  toggleRoot: HTMLElement | null;
+}
+
+function toDatasetRecord(dataset: DOMStringMap): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const [key, value] of Object.entries(dataset)) {
+    record[key] = value ?? "";
+  }
+  return record;
+}
+
+function normalizeSearchRecord(value: unknown): string {
+  if (value == null) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeSearchRecord(item)).join(" ");
+  }
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>)
+      .map((item) => normalizeSearchRecord(item))
+      .join(" ");
+  }
+  return String(value);
+}
+
+function resolveDatasetValue(
+  dataset: Record<string, string>,
+  attribute: string
+): string {
+  if (attribute in dataset) {
+    return dataset[attribute] ?? "";
+  }
+  const camelCased = attribute.replace(/-([a-z])/gi, (_, letter: string) =>
+    letter.toUpperCase()
+  );
+  if (camelCased in dataset) {
+    return dataset[camelCased] ?? "";
+  }
+  return "";
+}
+
+function readResourcePayload(
+  script: HTMLScriptElement | null
+): ResourceSearchEntry[] {
+  if (!script || !script.textContent) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(script.textContent) as unknown;
+    const payloadArray = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray((parsed as Record<string, unknown>)?.items)
+      ? ((parsed as Record<string, unknown>).items as unknown[])
+      : null;
+
+    if (!Array.isArray(payloadArray)) {
+      return [];
+    }
+
+    return payloadArray
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+        const idValue = (entry as Record<string, unknown>).id;
+        const id = normalizeSearchRecord(idValue);
+        if (!id) {
+          return null;
+        }
+        const result: ResourceSearchEntry = { id };
+        for (const [key, value] of Object.entries(
+          entry as Record<string, unknown>
+        )) {
+          if (key === "id") {
+            continue;
+          }
+          result[key] = normalizeSearchRecord(value);
+        }
+        return result;
+      })
+      .filter((entry): entry is ResourceSearchEntry => Boolean(entry));
+  } catch (error) {
+    console.warn("Failed to parse resource list payload", error);
+  }
+  return [];
+}
+
 export function setupResourceListFiltering({
   listSelector,
   formSelector = ".filter-form",
   favoritesField = "favoritesOnly",
   equalityFilters = [],
+  searchField,
+  fuzzyOptions,
 }: SetupResourceListFilteringOptions): () => void {
   const list = document.querySelector<HTMLElement>(listSelector);
   const form = document.querySelector<HTMLFormElement>(formSelector);
@@ -35,23 +138,156 @@ export function setupResourceListFiltering({
     return () => {};
   }
 
+  const buildResourceSelector = (key: string): string => {
+    if (!key) {
+      return "script[data-resource-list]";
+    }
+    const escapedKey =
+      typeof CSS !== "undefined" && typeof CSS.escape === "function"
+        ? CSS.escape(key)
+        : key.replace(/"/g, '\\"');
+    return `script[data-resource-list="${escapedKey}"]`;
+  };
+
+  const listId = list?.id ?? "";
+  const localSelector = buildResourceSelector(listId);
+  let resourceScript =
+    list?.parentElement?.querySelector<HTMLScriptElement>(localSelector) ?? null;
+
+  if (!resourceScript) {
+    resourceScript = document.querySelector<HTMLScriptElement>(localSelector);
+  }
+
+  if (!resourceScript) {
+    resourceScript = document.querySelector<HTMLScriptElement>(
+      "script[data-resource-list]"
+    );
+  }
+
+  const resourcePayload = readResourcePayload(resourceScript);
+  const payloadById = new Map(resourcePayload.map((entry) => [entry.id, entry]));
+
+  const resources: ResourceEntry[] = cards.map((card, index) => {
+    const datasetRecord = toDatasetRecord(card.dataset);
+    const datasetId =
+      datasetRecord.resourceId ||
+      datasetRecord.slug ||
+      datasetRecord.id ||
+      datasetRecord.key;
+    if (!datasetRecord.favorite) {
+      datasetRecord.favorite = card.dataset.favorite ?? "false";
+    }
+    const fallbackId = card.id || `resource-${index}`;
+    const id = datasetId || fallbackId;
+    const payload = payloadById.get(id);
+    const searchable: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(datasetRecord)) {
+      if (!value) {
+        continue;
+      }
+      searchable[key] = value;
+    }
+
+    if (payload) {
+      for (const [key, value] of Object.entries(payload)) {
+        if (key === "id" || !value) {
+          continue;
+        }
+        searchable[key] = value;
+      }
+    }
+
+    if (!searchable.name) {
+      const title = card.querySelector<HTMLElement>(".resource-card__title");
+      const titleText = title?.textContent?.trim();
+      if (titleText) {
+        searchable.name = titleText;
+      }
+    }
+
+    if (!searchable.description) {
+      const summary = card.querySelector<HTMLElement>(
+        ".resource-card__summary"
+      );
+      const summaryText = summary?.textContent?.trim();
+      if (summaryText) {
+        searchable.description = summaryText;
+      }
+    }
+
+    const contentText = card.textContent?.trim();
+    if (contentText) {
+      searchable.content = contentText;
+    }
+
+    if (!card.dataset.resourceId) {
+      card.dataset.resourceId = id;
+    }
+
+    return {
+      id,
+      card,
+      dataset: datasetRecord,
+      searchable,
+      toggleRoot: card.querySelector<HTMLElement>("[data-favorite-root]") ?? null,
+    };
+  });
+
+  const searchRecords: ResourceSearchEntry[] = resources.map((resource) => {
+    const record: ResourceSearchEntry = { id: resource.id };
+    for (const [key, value] of Object.entries(resource.searchable)) {
+      if (!value || key === "favorite" || key === "resourceId") {
+        continue;
+      }
+      record[key] = value;
+    }
+    return record;
+  });
+
+  const defaultKeyOptions = Array.from(
+    searchRecords.reduce((keys, record) => {
+      Object.keys(record).forEach((key) => {
+        if (key === "id") {
+          return;
+        }
+        keys.add(key);
+      });
+      return keys;
+    }, new Set<string>())
+  ).map((name) => ({ name }));
+
+  const fuzzyIndex =
+    searchField &&
+    searchRecords.length > 0 &&
+    ((fuzzyOptions?.keys?.length ?? 0) > 0 || defaultKeyOptions.length > 0)
+      ? new FuzzyIndex<ResourceSearchEntry>(searchRecords, {
+          keys: fuzzyOptions?.keys?.length
+            ? fuzzyOptions.keys
+            : defaultKeyOptions,
+          threshold: fuzzyOptions?.threshold,
+          minMatchCharLength: fuzzyOptions?.minMatchCharLength,
+        })
+      : null;
+
   let favoritesState: FavoritesState = {};
 
-  const resolveFavorite = (card: HTMLLIElement) => {
-    const toggleRoot = card.querySelector<HTMLElement>("[data-favorite-root]");
-    const key = toggleRoot?.dataset.favoriteKey ?? "";
+  const resolveFavorite = (resource: ResourceEntry) => {
+    const key = resource.toggleRoot?.dataset.favoriteKey ?? "";
     const storedFavorite = key ? favoritesState[key] : undefined;
     const isFavorite =
-      Boolean(storedFavorite) || card.dataset.favorite === "true";
+      Boolean(storedFavorite) || resource.dataset.favorite === "true";
 
-    return { toggleRoot, key, isFavorite } as const;
+    return { key, isFavorite } as const;
   };
 
   const applyFavorites = (items: FavoritesState) => {
     favoritesState = items ?? {};
-    cards.forEach((card) => {
-      const { toggleRoot, isFavorite } = resolveFavorite(card);
-      card.dataset.favorite = String(isFavorite);
+    resources.forEach((resource) => {
+      const { card, toggleRoot } = resource;
+      const { isFavorite } = resolveFavorite(resource);
+      resource.dataset.favorite = String(isFavorite);
+      card.dataset.favorite = resource.dataset.favorite;
       const button = toggleRoot?.querySelector<HTMLButtonElement>(
         "[data-favorite-button]"
       );
@@ -72,7 +308,6 @@ export function setupResourceListFiltering({
     return typeof value === "string" ? value : value != null ? String(value) : "";
   };
 
-
   const refreshFavoritesFromStorage = () => {
     const payload = loadFavorites();
     applyFavorites(payload.items);
@@ -83,7 +318,7 @@ export function setupResourceListFiltering({
 
     const activeFilters = equalityFilters.map((filter) => {
       const attribute = filter.dataAttribute ?? filter.field;
-      const value = getFormValue(formData, filter.field);
+      const value = getFormValue(formData, filter.field).trim();
       return { attribute, value };
     });
 
@@ -91,26 +326,71 @@ export function setupResourceListFiltering({
       favoritesField && formData ? formData.has(favoritesField) : false
     );
 
-    cards.forEach((card) => {
-      const { isFavorite } = resolveFavorite(card);
-      const matchesFavorites = !favoritesOnly || isFavorite;
+    const searchQuery = searchField
+      ? getFormValue(formData, searchField).trim()
+      : "";
+
+    let matchedIds: Set<string> | null = null;
+    if (searchField && searchQuery) {
+      if (fuzzyIndex) {
+        const results = fuzzyIndex.search(searchQuery);
+        matchedIds = new Set(results.map((result) => result.item.id));
+      } else {
+        const normalizedQuery = searchQuery.toLowerCase();
+        matchedIds = new Set(
+          resources
+            .filter((resource) =>
+              Object.values(resource.searchable).some((value) =>
+                value.toLowerCase().includes(normalizedQuery)
+              )
+            )
+            .map((resource) => resource.id)
+        );
+      }
+    }
+
+    resources.forEach((resource) => {
+      const matchesFavorites =
+        !favoritesOnly || resource.dataset.favorite === "true";
       const matchesEquality = activeFilters.every(({ attribute, value }) => {
         if (!value) {
           return true;
         }
-        const dataset = card.dataset as Record<string, string | undefined>;
-        return (dataset[attribute] ?? "") === value;
+        const datasetValue = resolveDatasetValue(resource.dataset, attribute);
+        return datasetValue === value;
       });
-      card.hidden = !(matchesFavorites && matchesEquality);
+      const matchesSearch =
+        !searchField || !searchQuery || matchedIds?.has(resource.id) === true;
+      resource.card.hidden = !(matchesFavorites && matchesEquality && matchesSearch);
     });
   };
 
+  const handleChange = () => {
+    applyFilters();
+  };
+
+  const handleInput = (event: Event) => {
+    if (!searchField) {
+      return;
+    }
+    const target = event.target as HTMLInputElement | null;
+    if (!target || target.name !== searchField) {
+      return;
+    }
+    applyFilters();
+  };
+
+  const handleReset = () => {
+    window.setTimeout(applyFilters, 0);
+  };
 
   refreshFavoritesFromStorage();
 
   applyFilters();
 
-  form?.addEventListener("change", applyFilters);
+  form?.addEventListener("change", handleChange);
+  form?.addEventListener("input", handleInput);
+  form?.addEventListener("reset", handleReset);
 
   const unsubscribe = subscribeToFavorites((detail) => {
     if (!detail || !detail.payload) return;
@@ -119,7 +399,9 @@ export function setupResourceListFiltering({
   });
 
   const cleanup = () => {
-    form?.removeEventListener("change", applyFilters);
+    form?.removeEventListener("change", handleChange);
+    form?.removeEventListener("input", handleInput);
+    form?.removeEventListener("reset", handleReset);
     unsubscribe?.();
   };
 


### PR DESCRIPTION
## Summary
- add a lightweight fuzzy index helper and rebuild the resource filter pipeline to use serialized list data, weighted search, and responsive input handling
- expose search inputs and JSON payloads on the exercises, warmups, and forms listings so the new filters can score metadata alongside favourites
- document the fuzzy search capability and capture follow-up tasks for automated interaction tests and a future Fuse.js swap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf7f71e4c832a9794af39e133efba