### PR TITLE
Refactor resource table client setup into modular helpers

### DIFF
--- a/public/scripts/exercises-table.client.js
+++ b/public/scripts/exercises-table.client.js
@@ -2949,55 +2949,8 @@ function normalize(value) {
 function extractText(card, selector) {
   return card.querySelector(selector)?.textContent?.trim() ?? "";
 }
-function setupResourceTable(options2) {
-  const {
-    listSelector,
-    formSelector = DEFAULT_FORM_SELECTOR,
-    searchField,
-    favoritesField = DEFAULT_FAVORITES_FIELD,
-    equalityFields = [],
-    columns: columnConfig,
-    debugLabel = "resourceTable"
-  } = options2;
-  const debugPrefix = `[${debugLabel}]`;
-  const logDebug = (message, detail) => {
-    if (typeof window === "undefined") return;
-    if (detail === void 0) {
-      console.info(`${debugPrefix} ${message}`);
-    } else {
-      console.info(`${debugPrefix} ${message}`, detail);
-    }
-  };
-  const list = document.querySelector(listSelector);
-  if (!list) {
-    logDebug("List selector did not resolve", { listSelector });
-    return () => {
-    };
-  }
-  const cards = Array.from(list.querySelectorAll(".resource-card"));
-  if (!cards.length) {
-    logDebug("No resource cards found", { listSelector });
-    return () => {
-    };
-  }
-  const columns = [
-    ...columnConfig,
-    {
-      key: "favorite",
-      filter: "equals",
-      enableGlobalFilter: false
-    }
-  ];
-  const columnHelper = createColumnHelper();
-  const columnDefs = columns.map(
-    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
-      id: key,
-      filterFn: filter === "equals" ? "equalsString" : "includesString",
-      enableSorting: false,
-      enableGlobalFilter
-    })
-  );
-  const resourceRows = cards.map((card, index) => {
+function buildResourceRows(cards, columns) {
+  return cards.map((card, index) => {
     const dataset = toDatasetRecord(card.dataset);
     const favoriteRoot = card.querySelector("[data-favorite-root]") ?? null;
     const favoriteButton = favoriteRoot?.querySelector(
@@ -3047,6 +3000,200 @@ function setupResourceTable(options2) {
     }
     return row;
   });
+}
+function initFavoritesSync({
+  resourceRows,
+  logDebug,
+  updateDataAndRender
+}) {
+  const applyFavorites = (payload) => {
+    resourceRows.forEach((row) => {
+      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
+      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
+      row.favorite = isFavorite ? "true" : "false";
+      row.cardElement.dataset.favorite = row.favorite;
+      if (row.favoriteRoot) {
+        row.favoriteRoot.dataset.favorite = row.favorite;
+      }
+      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
+    });
+    logDebug("Favorites applied", {
+      favorites: Object.keys(payload ?? {}).length
+    });
+    updateDataAndRender();
+  };
+  const favoritesPayload = loadFavorites();
+  applyFavorites(favoritesPayload.items);
+  const cleanupFavorites = subscribeToFavorites((detail) => {
+    if (!detail?.payload) {
+      return;
+    }
+    applyFavorites(detail.payload.items);
+  });
+  return typeof cleanupFavorites === "function" ? cleanupFavorites : () => {
+  };
+}
+function initFilterControls({
+  form,
+  table,
+  searchField,
+  favoritesField,
+  equalityFields,
+  logDebug,
+  onFiltersReset
+}) {
+  const syncFiltersFromForm = () => {
+    if (!form) {
+      return;
+    }
+    const formData = new FormData(form);
+    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
+    if (searchField) {
+      table.setGlobalFilter(query);
+    }
+    equalityFields.forEach((field) => {
+      const value = (formData.get(field) ?? "").toString().trim();
+      table.getColumn(field)?.setFilterValue(value || void 0);
+    });
+    if (favoritesField) {
+      const favoritesOnly = formData.get(favoritesField) != null;
+      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
+    }
+  };
+  function handleInput(event) {
+    if (!searchField) return;
+    const target = event.target;
+    if (!target || target.name !== searchField) {
+      return;
+    }
+    logDebug("Search input", { value: target.value });
+    table.setGlobalFilter(target.value);
+  }
+  function handleChange(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
+      logDebug("Favorites toggle", { active: target.checked });
+      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
+      return;
+    }
+    if (equalityFields.includes(target.name)) {
+      logDebug("Equality filter", { field: target.name, value: target.value });
+      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
+    }
+  }
+  function handleReset() {
+    window.setTimeout(() => {
+      logDebug("Form reset requested");
+      table.resetGlobalFilter();
+      table.resetColumnFilters();
+      onFiltersReset();
+    }, 0);
+  }
+  const handleSubmit = (event) => event.preventDefault();
+  form?.addEventListener("submit", handleSubmit);
+  form?.addEventListener("input", handleInput);
+  form?.addEventListener("change", handleChange);
+  form?.addEventListener("reset", handleReset);
+  if (typeof window !== "undefined" && window.location.search) {
+    const params = new URL(window.location.href).searchParams;
+    const applyQueue = [];
+    if (form) {
+      if (searchField) {
+        const queryValue = params.get(searchField);
+        if (queryValue != null) {
+          const input = form.elements.namedItem(searchField);
+          if (input && "value" in input) {
+            input.value = queryValue;
+            applyQueue.push(() => table.setGlobalFilter(queryValue));
+          }
+        }
+      }
+      equalityFields.forEach((field) => {
+        const value = params.get(field);
+        if (value != null) {
+          const element = form.elements.namedItem(field);
+          if (element && "value" in element) {
+            element.value = value;
+            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
+          }
+        }
+      });
+      if (favoritesField && params.has(favoritesField)) {
+        const favoritesInput = form.elements.namedItem(favoritesField);
+        if (favoritesInput instanceof HTMLInputElement) {
+          favoritesInput.checked = true;
+          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
+        }
+      }
+    }
+    applyQueue.forEach((fn) => fn());
+    if (params.toString()) {
+      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }
+  return {
+    cleanup: () => {
+      form?.removeEventListener("submit", handleSubmit);
+      form?.removeEventListener("input", handleInput);
+      form?.removeEventListener("change", handleChange);
+      form?.removeEventListener("reset", handleReset);
+    },
+    syncFiltersFromForm
+  };
+}
+function setupResourceTable(options2) {
+  const {
+    listSelector,
+    formSelector = DEFAULT_FORM_SELECTOR,
+    searchField,
+    favoritesField = DEFAULT_FAVORITES_FIELD,
+    equalityFields = [],
+    columns: columnConfig,
+    debugLabel = "resourceTable"
+  } = options2;
+  const debugPrefix = `[${debugLabel}]`;
+  const logDebug = (message, detail) => {
+    if (typeof window === "undefined") return;
+    if (detail === void 0) {
+      console.info(`${debugPrefix} ${message}`);
+    } else {
+      console.info(`${debugPrefix} ${message}`, detail);
+    }
+  };
+  const list = document.querySelector(listSelector);
+  if (!list) {
+    logDebug("List selector did not resolve", { listSelector });
+    return () => {
+    };
+  }
+  const cards = Array.from(list.querySelectorAll(".resource-card"));
+  if (!cards.length) {
+    logDebug("No resource cards found", { listSelector });
+    return () => {
+    };
+  }
+  const columns = [
+    ...columnConfig,
+    {
+      key: "favorite",
+      filter: "equals",
+      enableGlobalFilter: false
+    }
+  ];
+  const columnHelper = createColumnHelper();
+  const columnDefs = columns.map(
+    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
+      id: key,
+      filterFn: filter === "equals" ? "equalsString" : "includesString",
+      enableSorting: false,
+      enableGlobalFilter
+    })
+  );
+  const resourceRows = buildResourceRows(cards, columns);
   const emptyMessage = list.parentElement?.querySelector(
     "[data-resource-empty]"
   ) ?? (() => {
@@ -3118,126 +3265,29 @@ function setupResourceTable(options2) {
     }));
     render();
   }
-  function applyFavorites(payload) {
-    resourceRows.forEach((row) => {
-      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
-      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
-      row.favorite = isFavorite ? "true" : "false";
-      row.cardElement.dataset.favorite = row.favorite;
-      if (row.favoriteRoot) {
-        row.favoriteRoot.dataset.favorite = row.favorite;
-      }
-      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
-    });
-    logDebug("Favorites applied", {
-      favorites: Object.keys(payload ?? {}).length
-    });
-    updateDataAndRender();
-  }
-  function syncFiltersFromForm() {
-    if (!form) {
-      updateStateAndRender();
-      return;
-    }
-    const formData = new FormData(form);
-    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
-    if (searchField) {
-      table.setGlobalFilter(query);
-    }
-    equalityFields.forEach((field) => {
-      const value = (formData.get(field) ?? "").toString().trim();
-      table.getColumn(field)?.setFilterValue(value || void 0);
-    });
-    if (favoritesField) {
-      const favoritesOnly = formData.get(favoritesField) != null;
-      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
-    }
-  }
-  function handleInput(event) {
-    if (!searchField) return;
-    const target = event.target;
-    if (!target || target.name !== searchField) {
-      return;
-    }
-    logDebug("Search input", { value: target.value });
-    table.setGlobalFilter(target.value);
-  }
-  function handleChange(event) {
-    const target = event.target;
-    if (!target) {
-      return;
-    }
-    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
-      logDebug("Favorites toggle", { active: target.checked });
-      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
-      return;
-    }
-    if (equalityFields.includes(target.name)) {
-      logDebug("Equality filter", { field: target.name, value: target.value });
-      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
-    }
-  }
-  function handleReset() {
-    window.setTimeout(() => {
-      logDebug("Form reset requested");
-      table.resetGlobalFilter();
-      table.resetColumnFilters();
-      render();
-    }, 0);
-  }
-  const handleSubmit = (event) => event.preventDefault();
-  form?.addEventListener("submit", handleSubmit);
-  form?.addEventListener("input", handleInput);
-  form?.addEventListener("change", handleChange);
-  form?.addEventListener("reset", handleReset);
-  const favoritesPayload = loadFavorites();
-  applyFavorites(favoritesPayload.items);
-  const cleanupFavorites = subscribeToFavorites((detail) => {
-    if (!detail?.payload) {
-      return;
-    }
-    applyFavorites(detail.payload.items);
+  const cleanupFunctions = [];
+  const cleanupFavorites = initFavoritesSync({
+    resourceRows,
+    logDebug,
+    updateDataAndRender
   });
-  if (typeof window !== "undefined" && window.location.search) {
-    const params = new URL(window.location.href).searchParams;
-    const applyQueue = [];
-    if (form) {
-      if (searchField) {
-        const queryValue = params.get(searchField);
-        if (queryValue != null) {
-          const input = form.elements.namedItem(searchField);
-          if (input && "value" in input) {
-            input.value = queryValue;
-            applyQueue.push(() => table.setGlobalFilter(queryValue));
-          }
-        }
-      }
-      equalityFields.forEach((field) => {
-        const value = params.get(field);
-        if (value != null) {
-          const element = form.elements.namedItem(field);
-          if (element && "value" in element) {
-            element.value = value;
-            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
-          }
-        }
-      });
-      if (favoritesField && params.has(favoritesField)) {
-        const favoritesInput = form.elements.namedItem(favoritesField);
-        if (favoritesInput instanceof HTMLInputElement) {
-          favoritesInput.checked = true;
-          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
-        }
-      }
-    }
-    applyQueue.forEach((fn) => fn());
-    if (params.toString()) {
-      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
-      window.history.replaceState({}, document.title, nextUrl);
-    }
+  cleanupFunctions.push(cleanupFavorites);
+  const { cleanup: cleanupFilters, syncFiltersFromForm } = initFilterControls({
+    form,
+    table,
+    searchField,
+    favoritesField,
+    equalityFields,
+    logDebug,
+    onFiltersReset: updateStateAndRender
+  });
+  cleanupFunctions.push(cleanupFilters);
+  if (!form) {
+    updateStateAndRender();
+  } else {
+    syncFiltersFromForm();
+    updateStateAndRender();
   }
-  syncFiltersFromForm();
-  updateStateAndRender();
   logDebug("Table initialised", {
     rows: resourceRows.length,
     equalityFields,
@@ -3245,11 +3295,7 @@ function setupResourceTable(options2) {
     favoritesField
   });
   return () => {
-    form?.removeEventListener("submit", handleSubmit);
-    form?.removeEventListener("input", handleInput);
-    form?.removeEventListener("change", handleChange);
-    form?.removeEventListener("reset", handleReset);
-    cleanupFavorites?.();
+    cleanupFunctions.forEach((cleanup2) => cleanup2());
   };
 }
 

--- a/public/scripts/forms-table.client.js
+++ b/public/scripts/forms-table.client.js
@@ -2949,55 +2949,8 @@ function normalize(value) {
 function extractText(card, selector) {
   return card.querySelector(selector)?.textContent?.trim() ?? "";
 }
-function setupResourceTable(options2) {
-  const {
-    listSelector,
-    formSelector = DEFAULT_FORM_SELECTOR,
-    searchField,
-    favoritesField = DEFAULT_FAVORITES_FIELD,
-    equalityFields = [],
-    columns: columnConfig,
-    debugLabel = "resourceTable"
-  } = options2;
-  const debugPrefix = `[${debugLabel}]`;
-  const logDebug = (message, detail) => {
-    if (typeof window === "undefined") return;
-    if (detail === void 0) {
-      console.info(`${debugPrefix} ${message}`);
-    } else {
-      console.info(`${debugPrefix} ${message}`, detail);
-    }
-  };
-  const list = document.querySelector(listSelector);
-  if (!list) {
-    logDebug("List selector did not resolve", { listSelector });
-    return () => {
-    };
-  }
-  const cards = Array.from(list.querySelectorAll(".resource-card"));
-  if (!cards.length) {
-    logDebug("No resource cards found", { listSelector });
-    return () => {
-    };
-  }
-  const columns = [
-    ...columnConfig,
-    {
-      key: "favorite",
-      filter: "equals",
-      enableGlobalFilter: false
-    }
-  ];
-  const columnHelper = createColumnHelper();
-  const columnDefs = columns.map(
-    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
-      id: key,
-      filterFn: filter === "equals" ? "equalsString" : "includesString",
-      enableSorting: false,
-      enableGlobalFilter
-    })
-  );
-  const resourceRows = cards.map((card, index) => {
+function buildResourceRows(cards, columns) {
+  return cards.map((card, index) => {
     const dataset = toDatasetRecord(card.dataset);
     const favoriteRoot = card.querySelector("[data-favorite-root]") ?? null;
     const favoriteButton = favoriteRoot?.querySelector(
@@ -3047,6 +3000,200 @@ function setupResourceTable(options2) {
     }
     return row;
   });
+}
+function initFavoritesSync({
+  resourceRows,
+  logDebug,
+  updateDataAndRender
+}) {
+  const applyFavorites = (payload) => {
+    resourceRows.forEach((row) => {
+      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
+      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
+      row.favorite = isFavorite ? "true" : "false";
+      row.cardElement.dataset.favorite = row.favorite;
+      if (row.favoriteRoot) {
+        row.favoriteRoot.dataset.favorite = row.favorite;
+      }
+      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
+    });
+    logDebug("Favorites applied", {
+      favorites: Object.keys(payload ?? {}).length
+    });
+    updateDataAndRender();
+  };
+  const favoritesPayload = loadFavorites();
+  applyFavorites(favoritesPayload.items);
+  const cleanupFavorites = subscribeToFavorites((detail) => {
+    if (!detail?.payload) {
+      return;
+    }
+    applyFavorites(detail.payload.items);
+  });
+  return typeof cleanupFavorites === "function" ? cleanupFavorites : () => {
+  };
+}
+function initFilterControls({
+  form,
+  table,
+  searchField,
+  favoritesField,
+  equalityFields,
+  logDebug,
+  onFiltersReset
+}) {
+  const syncFiltersFromForm = () => {
+    if (!form) {
+      return;
+    }
+    const formData = new FormData(form);
+    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
+    if (searchField) {
+      table.setGlobalFilter(query);
+    }
+    equalityFields.forEach((field) => {
+      const value = (formData.get(field) ?? "").toString().trim();
+      table.getColumn(field)?.setFilterValue(value || void 0);
+    });
+    if (favoritesField) {
+      const favoritesOnly = formData.get(favoritesField) != null;
+      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
+    }
+  };
+  function handleInput(event) {
+    if (!searchField) return;
+    const target = event.target;
+    if (!target || target.name !== searchField) {
+      return;
+    }
+    logDebug("Search input", { value: target.value });
+    table.setGlobalFilter(target.value);
+  }
+  function handleChange(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
+      logDebug("Favorites toggle", { active: target.checked });
+      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
+      return;
+    }
+    if (equalityFields.includes(target.name)) {
+      logDebug("Equality filter", { field: target.name, value: target.value });
+      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
+    }
+  }
+  function handleReset() {
+    window.setTimeout(() => {
+      logDebug("Form reset requested");
+      table.resetGlobalFilter();
+      table.resetColumnFilters();
+      onFiltersReset();
+    }, 0);
+  }
+  const handleSubmit = (event) => event.preventDefault();
+  form?.addEventListener("submit", handleSubmit);
+  form?.addEventListener("input", handleInput);
+  form?.addEventListener("change", handleChange);
+  form?.addEventListener("reset", handleReset);
+  if (typeof window !== "undefined" && window.location.search) {
+    const params = new URL(window.location.href).searchParams;
+    const applyQueue = [];
+    if (form) {
+      if (searchField) {
+        const queryValue = params.get(searchField);
+        if (queryValue != null) {
+          const input = form.elements.namedItem(searchField);
+          if (input && "value" in input) {
+            input.value = queryValue;
+            applyQueue.push(() => table.setGlobalFilter(queryValue));
+          }
+        }
+      }
+      equalityFields.forEach((field) => {
+        const value = params.get(field);
+        if (value != null) {
+          const element = form.elements.namedItem(field);
+          if (element && "value" in element) {
+            element.value = value;
+            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
+          }
+        }
+      });
+      if (favoritesField && params.has(favoritesField)) {
+        const favoritesInput = form.elements.namedItem(favoritesField);
+        if (favoritesInput instanceof HTMLInputElement) {
+          favoritesInput.checked = true;
+          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
+        }
+      }
+    }
+    applyQueue.forEach((fn) => fn());
+    if (params.toString()) {
+      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }
+  return {
+    cleanup: () => {
+      form?.removeEventListener("submit", handleSubmit);
+      form?.removeEventListener("input", handleInput);
+      form?.removeEventListener("change", handleChange);
+      form?.removeEventListener("reset", handleReset);
+    },
+    syncFiltersFromForm
+  };
+}
+function setupResourceTable(options2) {
+  const {
+    listSelector,
+    formSelector = DEFAULT_FORM_SELECTOR,
+    searchField,
+    favoritesField = DEFAULT_FAVORITES_FIELD,
+    equalityFields = [],
+    columns: columnConfig,
+    debugLabel = "resourceTable"
+  } = options2;
+  const debugPrefix = `[${debugLabel}]`;
+  const logDebug = (message, detail) => {
+    if (typeof window === "undefined") return;
+    if (detail === void 0) {
+      console.info(`${debugPrefix} ${message}`);
+    } else {
+      console.info(`${debugPrefix} ${message}`, detail);
+    }
+  };
+  const list = document.querySelector(listSelector);
+  if (!list) {
+    logDebug("List selector did not resolve", { listSelector });
+    return () => {
+    };
+  }
+  const cards = Array.from(list.querySelectorAll(".resource-card"));
+  if (!cards.length) {
+    logDebug("No resource cards found", { listSelector });
+    return () => {
+    };
+  }
+  const columns = [
+    ...columnConfig,
+    {
+      key: "favorite",
+      filter: "equals",
+      enableGlobalFilter: false
+    }
+  ];
+  const columnHelper = createColumnHelper();
+  const columnDefs = columns.map(
+    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
+      id: key,
+      filterFn: filter === "equals" ? "equalsString" : "includesString",
+      enableSorting: false,
+      enableGlobalFilter
+    })
+  );
+  const resourceRows = buildResourceRows(cards, columns);
   const emptyMessage = list.parentElement?.querySelector(
     "[data-resource-empty]"
   ) ?? (() => {
@@ -3118,126 +3265,29 @@ function setupResourceTable(options2) {
     }));
     render();
   }
-  function applyFavorites(payload) {
-    resourceRows.forEach((row) => {
-      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
-      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
-      row.favorite = isFavorite ? "true" : "false";
-      row.cardElement.dataset.favorite = row.favorite;
-      if (row.favoriteRoot) {
-        row.favoriteRoot.dataset.favorite = row.favorite;
-      }
-      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
-    });
-    logDebug("Favorites applied", {
-      favorites: Object.keys(payload ?? {}).length
-    });
-    updateDataAndRender();
-  }
-  function syncFiltersFromForm() {
-    if (!form) {
-      updateStateAndRender();
-      return;
-    }
-    const formData = new FormData(form);
-    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
-    if (searchField) {
-      table.setGlobalFilter(query);
-    }
-    equalityFields.forEach((field) => {
-      const value = (formData.get(field) ?? "").toString().trim();
-      table.getColumn(field)?.setFilterValue(value || void 0);
-    });
-    if (favoritesField) {
-      const favoritesOnly = formData.get(favoritesField) != null;
-      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
-    }
-  }
-  function handleInput(event) {
-    if (!searchField) return;
-    const target = event.target;
-    if (!target || target.name !== searchField) {
-      return;
-    }
-    logDebug("Search input", { value: target.value });
-    table.setGlobalFilter(target.value);
-  }
-  function handleChange(event) {
-    const target = event.target;
-    if (!target) {
-      return;
-    }
-    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
-      logDebug("Favorites toggle", { active: target.checked });
-      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
-      return;
-    }
-    if (equalityFields.includes(target.name)) {
-      logDebug("Equality filter", { field: target.name, value: target.value });
-      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
-    }
-  }
-  function handleReset() {
-    window.setTimeout(() => {
-      logDebug("Form reset requested");
-      table.resetGlobalFilter();
-      table.resetColumnFilters();
-      render();
-    }, 0);
-  }
-  const handleSubmit = (event) => event.preventDefault();
-  form?.addEventListener("submit", handleSubmit);
-  form?.addEventListener("input", handleInput);
-  form?.addEventListener("change", handleChange);
-  form?.addEventListener("reset", handleReset);
-  const favoritesPayload = loadFavorites();
-  applyFavorites(favoritesPayload.items);
-  const cleanupFavorites = subscribeToFavorites((detail) => {
-    if (!detail?.payload) {
-      return;
-    }
-    applyFavorites(detail.payload.items);
+  const cleanupFunctions = [];
+  const cleanupFavorites = initFavoritesSync({
+    resourceRows,
+    logDebug,
+    updateDataAndRender
   });
-  if (typeof window !== "undefined" && window.location.search) {
-    const params = new URL(window.location.href).searchParams;
-    const applyQueue = [];
-    if (form) {
-      if (searchField) {
-        const queryValue = params.get(searchField);
-        if (queryValue != null) {
-          const input = form.elements.namedItem(searchField);
-          if (input && "value" in input) {
-            input.value = queryValue;
-            applyQueue.push(() => table.setGlobalFilter(queryValue));
-          }
-        }
-      }
-      equalityFields.forEach((field) => {
-        const value = params.get(field);
-        if (value != null) {
-          const element = form.elements.namedItem(field);
-          if (element && "value" in element) {
-            element.value = value;
-            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
-          }
-        }
-      });
-      if (favoritesField && params.has(favoritesField)) {
-        const favoritesInput = form.elements.namedItem(favoritesField);
-        if (favoritesInput instanceof HTMLInputElement) {
-          favoritesInput.checked = true;
-          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
-        }
-      }
-    }
-    applyQueue.forEach((fn) => fn());
-    if (params.toString()) {
-      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
-      window.history.replaceState({}, document.title, nextUrl);
-    }
+  cleanupFunctions.push(cleanupFavorites);
+  const { cleanup: cleanupFilters, syncFiltersFromForm } = initFilterControls({
+    form,
+    table,
+    searchField,
+    favoritesField,
+    equalityFields,
+    logDebug,
+    onFiltersReset: updateStateAndRender
+  });
+  cleanupFunctions.push(cleanupFilters);
+  if (!form) {
+    updateStateAndRender();
+  } else {
+    syncFiltersFromForm();
+    updateStateAndRender();
   }
-  syncFiltersFromForm();
-  updateStateAndRender();
   logDebug("Table initialised", {
     rows: resourceRows.length,
     equalityFields,
@@ -3245,11 +3295,7 @@ function setupResourceTable(options2) {
     favoritesField
   });
   return () => {
-    form?.removeEventListener("submit", handleSubmit);
-    form?.removeEventListener("input", handleInput);
-    form?.removeEventListener("change", handleChange);
-    form?.removeEventListener("reset", handleReset);
-    cleanupFavorites?.();
+    cleanupFunctions.forEach((cleanup2) => cleanup2());
   };
 }
 

--- a/public/scripts/resource-table.client.js
+++ b/public/scripts/resource-table.client.js
@@ -2949,55 +2949,8 @@ function normalize(value) {
 function extractText(card, selector) {
   return card.querySelector(selector)?.textContent?.trim() ?? "";
 }
-function setupResourceTable(options) {
-  const {
-    listSelector,
-    formSelector = DEFAULT_FORM_SELECTOR,
-    searchField,
-    favoritesField = DEFAULT_FAVORITES_FIELD,
-    equalityFields = [],
-    columns: columnConfig,
-    debugLabel = "resourceTable"
-  } = options;
-  const debugPrefix = `[${debugLabel}]`;
-  const logDebug = (message, detail) => {
-    if (typeof window === "undefined") return;
-    if (detail === void 0) {
-      console.info(`${debugPrefix} ${message}`);
-    } else {
-      console.info(`${debugPrefix} ${message}`, detail);
-    }
-  };
-  const list = document.querySelector(listSelector);
-  if (!list) {
-    logDebug("List selector did not resolve", { listSelector });
-    return () => {
-    };
-  }
-  const cards = Array.from(list.querySelectorAll(".resource-card"));
-  if (!cards.length) {
-    logDebug("No resource cards found", { listSelector });
-    return () => {
-    };
-  }
-  const columns = [
-    ...columnConfig,
-    {
-      key: "favorite",
-      filter: "equals",
-      enableGlobalFilter: false
-    }
-  ];
-  const columnHelper = createColumnHelper();
-  const columnDefs = columns.map(
-    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
-      id: key,
-      filterFn: filter === "equals" ? "equalsString" : "includesString",
-      enableSorting: false,
-      enableGlobalFilter
-    })
-  );
-  const resourceRows = cards.map((card, index) => {
+function buildResourceRows(cards, columns) {
+  return cards.map((card, index) => {
     const dataset = toDatasetRecord(card.dataset);
     const favoriteRoot = card.querySelector("[data-favorite-root]") ?? null;
     const favoriteButton = favoriteRoot?.querySelector(
@@ -3047,6 +3000,200 @@ function setupResourceTable(options) {
     }
     return row;
   });
+}
+function initFavoritesSync({
+  resourceRows,
+  logDebug,
+  updateDataAndRender
+}) {
+  const applyFavorites = (payload) => {
+    resourceRows.forEach((row) => {
+      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
+      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
+      row.favorite = isFavorite ? "true" : "false";
+      row.cardElement.dataset.favorite = row.favorite;
+      if (row.favoriteRoot) {
+        row.favoriteRoot.dataset.favorite = row.favorite;
+      }
+      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
+    });
+    logDebug("Favorites applied", {
+      favorites: Object.keys(payload ?? {}).length
+    });
+    updateDataAndRender();
+  };
+  const favoritesPayload = loadFavorites();
+  applyFavorites(favoritesPayload.items);
+  const cleanupFavorites = subscribeToFavorites((detail) => {
+    if (!detail?.payload) {
+      return;
+    }
+    applyFavorites(detail.payload.items);
+  });
+  return typeof cleanupFavorites === "function" ? cleanupFavorites : () => {
+  };
+}
+function initFilterControls({
+  form,
+  table,
+  searchField,
+  favoritesField,
+  equalityFields,
+  logDebug,
+  onFiltersReset
+}) {
+  const syncFiltersFromForm = () => {
+    if (!form) {
+      return;
+    }
+    const formData = new FormData(form);
+    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
+    if (searchField) {
+      table.setGlobalFilter(query);
+    }
+    equalityFields.forEach((field) => {
+      const value = (formData.get(field) ?? "").toString().trim();
+      table.getColumn(field)?.setFilterValue(value || void 0);
+    });
+    if (favoritesField) {
+      const favoritesOnly = formData.get(favoritesField) != null;
+      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
+    }
+  };
+  function handleInput(event) {
+    if (!searchField) return;
+    const target = event.target;
+    if (!target || target.name !== searchField) {
+      return;
+    }
+    logDebug("Search input", { value: target.value });
+    table.setGlobalFilter(target.value);
+  }
+  function handleChange(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
+      logDebug("Favorites toggle", { active: target.checked });
+      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
+      return;
+    }
+    if (equalityFields.includes(target.name)) {
+      logDebug("Equality filter", { field: target.name, value: target.value });
+      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
+    }
+  }
+  function handleReset() {
+    window.setTimeout(() => {
+      logDebug("Form reset requested");
+      table.resetGlobalFilter();
+      table.resetColumnFilters();
+      onFiltersReset();
+    }, 0);
+  }
+  const handleSubmit = (event) => event.preventDefault();
+  form?.addEventListener("submit", handleSubmit);
+  form?.addEventListener("input", handleInput);
+  form?.addEventListener("change", handleChange);
+  form?.addEventListener("reset", handleReset);
+  if (typeof window !== "undefined" && window.location.search) {
+    const params = new URL(window.location.href).searchParams;
+    const applyQueue = [];
+    if (form) {
+      if (searchField) {
+        const queryValue = params.get(searchField);
+        if (queryValue != null) {
+          const input = form.elements.namedItem(searchField);
+          if (input && "value" in input) {
+            input.value = queryValue;
+            applyQueue.push(() => table.setGlobalFilter(queryValue));
+          }
+        }
+      }
+      equalityFields.forEach((field) => {
+        const value = params.get(field);
+        if (value != null) {
+          const element = form.elements.namedItem(field);
+          if (element && "value" in element) {
+            element.value = value;
+            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
+          }
+        }
+      });
+      if (favoritesField && params.has(favoritesField)) {
+        const favoritesInput = form.elements.namedItem(favoritesField);
+        if (favoritesInput instanceof HTMLInputElement) {
+          favoritesInput.checked = true;
+          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
+        }
+      }
+    }
+    applyQueue.forEach((fn) => fn());
+    if (params.toString()) {
+      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }
+  return {
+    cleanup: () => {
+      form?.removeEventListener("submit", handleSubmit);
+      form?.removeEventListener("input", handleInput);
+      form?.removeEventListener("change", handleChange);
+      form?.removeEventListener("reset", handleReset);
+    },
+    syncFiltersFromForm
+  };
+}
+function setupResourceTable(options) {
+  const {
+    listSelector,
+    formSelector = DEFAULT_FORM_SELECTOR,
+    searchField,
+    favoritesField = DEFAULT_FAVORITES_FIELD,
+    equalityFields = [],
+    columns: columnConfig,
+    debugLabel = "resourceTable"
+  } = options;
+  const debugPrefix = `[${debugLabel}]`;
+  const logDebug = (message, detail) => {
+    if (typeof window === "undefined") return;
+    if (detail === void 0) {
+      console.info(`${debugPrefix} ${message}`);
+    } else {
+      console.info(`${debugPrefix} ${message}`, detail);
+    }
+  };
+  const list = document.querySelector(listSelector);
+  if (!list) {
+    logDebug("List selector did not resolve", { listSelector });
+    return () => {
+    };
+  }
+  const cards = Array.from(list.querySelectorAll(".resource-card"));
+  if (!cards.length) {
+    logDebug("No resource cards found", { listSelector });
+    return () => {
+    };
+  }
+  const columns = [
+    ...columnConfig,
+    {
+      key: "favorite",
+      filter: "equals",
+      enableGlobalFilter: false
+    }
+  ];
+  const columnHelper = createColumnHelper();
+  const columnDefs = columns.map(
+    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
+      id: key,
+      filterFn: filter === "equals" ? "equalsString" : "includesString",
+      enableSorting: false,
+      enableGlobalFilter
+    })
+  );
+  const resourceRows = buildResourceRows(cards, columns);
   const emptyMessage = list.parentElement?.querySelector(
     "[data-resource-empty]"
   ) ?? (() => {
@@ -3118,126 +3265,29 @@ function setupResourceTable(options) {
     }));
     render();
   }
-  function applyFavorites(payload) {
-    resourceRows.forEach((row) => {
-      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
-      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
-      row.favorite = isFavorite ? "true" : "false";
-      row.cardElement.dataset.favorite = row.favorite;
-      if (row.favoriteRoot) {
-        row.favoriteRoot.dataset.favorite = row.favorite;
-      }
-      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
-    });
-    logDebug("Favorites applied", {
-      favorites: Object.keys(payload ?? {}).length
-    });
-    updateDataAndRender();
-  }
-  function syncFiltersFromForm() {
-    if (!form) {
-      updateStateAndRender();
-      return;
-    }
-    const formData = new FormData(form);
-    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
-    if (searchField) {
-      table.setGlobalFilter(query);
-    }
-    equalityFields.forEach((field) => {
-      const value = (formData.get(field) ?? "").toString().trim();
-      table.getColumn(field)?.setFilterValue(value || void 0);
-    });
-    if (favoritesField) {
-      const favoritesOnly = formData.get(favoritesField) != null;
-      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
-    }
-  }
-  function handleInput(event) {
-    if (!searchField) return;
-    const target = event.target;
-    if (!target || target.name !== searchField) {
-      return;
-    }
-    logDebug("Search input", { value: target.value });
-    table.setGlobalFilter(target.value);
-  }
-  function handleChange(event) {
-    const target = event.target;
-    if (!target) {
-      return;
-    }
-    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
-      logDebug("Favorites toggle", { active: target.checked });
-      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
-      return;
-    }
-    if (equalityFields.includes(target.name)) {
-      logDebug("Equality filter", { field: target.name, value: target.value });
-      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
-    }
-  }
-  function handleReset() {
-    window.setTimeout(() => {
-      logDebug("Form reset requested");
-      table.resetGlobalFilter();
-      table.resetColumnFilters();
-      render();
-    }, 0);
-  }
-  const handleSubmit = (event) => event.preventDefault();
-  form?.addEventListener("submit", handleSubmit);
-  form?.addEventListener("input", handleInput);
-  form?.addEventListener("change", handleChange);
-  form?.addEventListener("reset", handleReset);
-  const favoritesPayload = loadFavorites();
-  applyFavorites(favoritesPayload.items);
-  const cleanupFavorites = subscribeToFavorites((detail) => {
-    if (!detail?.payload) {
-      return;
-    }
-    applyFavorites(detail.payload.items);
+  const cleanupFunctions = [];
+  const cleanupFavorites = initFavoritesSync({
+    resourceRows,
+    logDebug,
+    updateDataAndRender
   });
-  if (typeof window !== "undefined" && window.location.search) {
-    const params = new URL(window.location.href).searchParams;
-    const applyQueue = [];
-    if (form) {
-      if (searchField) {
-        const queryValue = params.get(searchField);
-        if (queryValue != null) {
-          const input = form.elements.namedItem(searchField);
-          if (input && "value" in input) {
-            input.value = queryValue;
-            applyQueue.push(() => table.setGlobalFilter(queryValue));
-          }
-        }
-      }
-      equalityFields.forEach((field) => {
-        const value = params.get(field);
-        if (value != null) {
-          const element = form.elements.namedItem(field);
-          if (element && "value" in element) {
-            element.value = value;
-            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
-          }
-        }
-      });
-      if (favoritesField && params.has(favoritesField)) {
-        const favoritesInput = form.elements.namedItem(favoritesField);
-        if (favoritesInput instanceof HTMLInputElement) {
-          favoritesInput.checked = true;
-          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
-        }
-      }
-    }
-    applyQueue.forEach((fn) => fn());
-    if (params.toString()) {
-      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
-      window.history.replaceState({}, document.title, nextUrl);
-    }
+  cleanupFunctions.push(cleanupFavorites);
+  const { cleanup: cleanupFilters, syncFiltersFromForm } = initFilterControls({
+    form,
+    table,
+    searchField,
+    favoritesField,
+    equalityFields,
+    logDebug,
+    onFiltersReset: updateStateAndRender
+  });
+  cleanupFunctions.push(cleanupFilters);
+  if (!form) {
+    updateStateAndRender();
+  } else {
+    syncFiltersFromForm();
+    updateStateAndRender();
   }
-  syncFiltersFromForm();
-  updateStateAndRender();
   logDebug("Table initialised", {
     rows: resourceRows.length,
     equalityFields,
@@ -3245,11 +3295,7 @@ function setupResourceTable(options) {
     favoritesField
   });
   return () => {
-    form?.removeEventListener("submit", handleSubmit);
-    form?.removeEventListener("input", handleInput);
-    form?.removeEventListener("change", handleChange);
-    form?.removeEventListener("reset", handleReset);
-    cleanupFavorites?.();
+    cleanupFunctions.forEach((cleanup) => cleanup());
   };
 }
 export {

--- a/public/scripts/warmups-table.client.js
+++ b/public/scripts/warmups-table.client.js
@@ -2949,55 +2949,8 @@ function normalize(value) {
 function extractText(card, selector) {
   return card.querySelector(selector)?.textContent?.trim() ?? "";
 }
-function setupResourceTable(options2) {
-  const {
-    listSelector,
-    formSelector = DEFAULT_FORM_SELECTOR,
-    searchField,
-    favoritesField = DEFAULT_FAVORITES_FIELD,
-    equalityFields = [],
-    columns: columnConfig,
-    debugLabel = "resourceTable"
-  } = options2;
-  const debugPrefix = `[${debugLabel}]`;
-  const logDebug = (message, detail) => {
-    if (typeof window === "undefined") return;
-    if (detail === void 0) {
-      console.info(`${debugPrefix} ${message}`);
-    } else {
-      console.info(`${debugPrefix} ${message}`, detail);
-    }
-  };
-  const list = document.querySelector(listSelector);
-  if (!list) {
-    logDebug("List selector did not resolve", { listSelector });
-    return () => {
-    };
-  }
-  const cards = Array.from(list.querySelectorAll(".resource-card"));
-  if (!cards.length) {
-    logDebug("No resource cards found", { listSelector });
-    return () => {
-    };
-  }
-  const columns = [
-    ...columnConfig,
-    {
-      key: "favorite",
-      filter: "equals",
-      enableGlobalFilter: false
-    }
-  ];
-  const columnHelper = createColumnHelper();
-  const columnDefs = columns.map(
-    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
-      id: key,
-      filterFn: filter === "equals" ? "equalsString" : "includesString",
-      enableSorting: false,
-      enableGlobalFilter
-    })
-  );
-  const resourceRows = cards.map((card, index) => {
+function buildResourceRows(cards, columns) {
+  return cards.map((card, index) => {
     const dataset = toDatasetRecord(card.dataset);
     const favoriteRoot = card.querySelector("[data-favorite-root]") ?? null;
     const favoriteButton = favoriteRoot?.querySelector(
@@ -3047,6 +3000,200 @@ function setupResourceTable(options2) {
     }
     return row;
   });
+}
+function initFavoritesSync({
+  resourceRows,
+  logDebug,
+  updateDataAndRender
+}) {
+  const applyFavorites = (payload) => {
+    resourceRows.forEach((row) => {
+      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
+      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
+      row.favorite = isFavorite ? "true" : "false";
+      row.cardElement.dataset.favorite = row.favorite;
+      if (row.favoriteRoot) {
+        row.favoriteRoot.dataset.favorite = row.favorite;
+      }
+      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
+    });
+    logDebug("Favorites applied", {
+      favorites: Object.keys(payload ?? {}).length
+    });
+    updateDataAndRender();
+  };
+  const favoritesPayload = loadFavorites();
+  applyFavorites(favoritesPayload.items);
+  const cleanupFavorites = subscribeToFavorites((detail) => {
+    if (!detail?.payload) {
+      return;
+    }
+    applyFavorites(detail.payload.items);
+  });
+  return typeof cleanupFavorites === "function" ? cleanupFavorites : () => {
+  };
+}
+function initFilterControls({
+  form,
+  table,
+  searchField,
+  favoritesField,
+  equalityFields,
+  logDebug,
+  onFiltersReset
+}) {
+  const syncFiltersFromForm = () => {
+    if (!form) {
+      return;
+    }
+    const formData = new FormData(form);
+    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
+    if (searchField) {
+      table.setGlobalFilter(query);
+    }
+    equalityFields.forEach((field) => {
+      const value = (formData.get(field) ?? "").toString().trim();
+      table.getColumn(field)?.setFilterValue(value || void 0);
+    });
+    if (favoritesField) {
+      const favoritesOnly = formData.get(favoritesField) != null;
+      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
+    }
+  };
+  function handleInput(event) {
+    if (!searchField) return;
+    const target = event.target;
+    if (!target || target.name !== searchField) {
+      return;
+    }
+    logDebug("Search input", { value: target.value });
+    table.setGlobalFilter(target.value);
+  }
+  function handleChange(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
+      logDebug("Favorites toggle", { active: target.checked });
+      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
+      return;
+    }
+    if (equalityFields.includes(target.name)) {
+      logDebug("Equality filter", { field: target.name, value: target.value });
+      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
+    }
+  }
+  function handleReset() {
+    window.setTimeout(() => {
+      logDebug("Form reset requested");
+      table.resetGlobalFilter();
+      table.resetColumnFilters();
+      onFiltersReset();
+    }, 0);
+  }
+  const handleSubmit = (event) => event.preventDefault();
+  form?.addEventListener("submit", handleSubmit);
+  form?.addEventListener("input", handleInput);
+  form?.addEventListener("change", handleChange);
+  form?.addEventListener("reset", handleReset);
+  if (typeof window !== "undefined" && window.location.search) {
+    const params = new URL(window.location.href).searchParams;
+    const applyQueue = [];
+    if (form) {
+      if (searchField) {
+        const queryValue = params.get(searchField);
+        if (queryValue != null) {
+          const input = form.elements.namedItem(searchField);
+          if (input && "value" in input) {
+            input.value = queryValue;
+            applyQueue.push(() => table.setGlobalFilter(queryValue));
+          }
+        }
+      }
+      equalityFields.forEach((field) => {
+        const value = params.get(field);
+        if (value != null) {
+          const element = form.elements.namedItem(field);
+          if (element && "value" in element) {
+            element.value = value;
+            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
+          }
+        }
+      });
+      if (favoritesField && params.has(favoritesField)) {
+        const favoritesInput = form.elements.namedItem(favoritesField);
+        if (favoritesInput instanceof HTMLInputElement) {
+          favoritesInput.checked = true;
+          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
+        }
+      }
+    }
+    applyQueue.forEach((fn) => fn());
+    if (params.toString()) {
+      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }
+  return {
+    cleanup: () => {
+      form?.removeEventListener("submit", handleSubmit);
+      form?.removeEventListener("input", handleInput);
+      form?.removeEventListener("change", handleChange);
+      form?.removeEventListener("reset", handleReset);
+    },
+    syncFiltersFromForm
+  };
+}
+function setupResourceTable(options2) {
+  const {
+    listSelector,
+    formSelector = DEFAULT_FORM_SELECTOR,
+    searchField,
+    favoritesField = DEFAULT_FAVORITES_FIELD,
+    equalityFields = [],
+    columns: columnConfig,
+    debugLabel = "resourceTable"
+  } = options2;
+  const debugPrefix = `[${debugLabel}]`;
+  const logDebug = (message, detail) => {
+    if (typeof window === "undefined") return;
+    if (detail === void 0) {
+      console.info(`${debugPrefix} ${message}`);
+    } else {
+      console.info(`${debugPrefix} ${message}`, detail);
+    }
+  };
+  const list = document.querySelector(listSelector);
+  if (!list) {
+    logDebug("List selector did not resolve", { listSelector });
+    return () => {
+    };
+  }
+  const cards = Array.from(list.querySelectorAll(".resource-card"));
+  if (!cards.length) {
+    logDebug("No resource cards found", { listSelector });
+    return () => {
+    };
+  }
+  const columns = [
+    ...columnConfig,
+    {
+      key: "favorite",
+      filter: "equals",
+      enableGlobalFilter: false
+    }
+  ];
+  const columnHelper = createColumnHelper();
+  const columnDefs = columns.map(
+    ({ key, filter, enableGlobalFilter = true }) => columnHelper.accessor((row) => row[key] ?? "", {
+      id: key,
+      filterFn: filter === "equals" ? "equalsString" : "includesString",
+      enableSorting: false,
+      enableGlobalFilter
+    })
+  );
+  const resourceRows = buildResourceRows(cards, columns);
   const emptyMessage = list.parentElement?.querySelector(
     "[data-resource-empty]"
   ) ?? (() => {
@@ -3118,126 +3265,29 @@ function setupResourceTable(options2) {
     }));
     render();
   }
-  function applyFavorites(payload) {
-    resourceRows.forEach((row) => {
-      const stored = row.favoriteKey ? payload[row.favoriteKey] : void 0;
-      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
-      row.favorite = isFavorite ? "true" : "false";
-      row.cardElement.dataset.favorite = row.favorite;
-      if (row.favoriteRoot) {
-        row.favoriteRoot.dataset.favorite = row.favorite;
-      }
-      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
-    });
-    logDebug("Favorites applied", {
-      favorites: Object.keys(payload ?? {}).length
-    });
-    updateDataAndRender();
-  }
-  function syncFiltersFromForm() {
-    if (!form) {
-      updateStateAndRender();
-      return;
-    }
-    const formData = new FormData(form);
-    const query = searchField ? (formData.get(searchField) ?? "").toString().trim() : "";
-    if (searchField) {
-      table.setGlobalFilter(query);
-    }
-    equalityFields.forEach((field) => {
-      const value = (formData.get(field) ?? "").toString().trim();
-      table.getColumn(field)?.setFilterValue(value || void 0);
-    });
-    if (favoritesField) {
-      const favoritesOnly = formData.get(favoritesField) != null;
-      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : void 0);
-    }
-  }
-  function handleInput(event) {
-    if (!searchField) return;
-    const target = event.target;
-    if (!target || target.name !== searchField) {
-      return;
-    }
-    logDebug("Search input", { value: target.value });
-    table.setGlobalFilter(target.value);
-  }
-  function handleChange(event) {
-    const target = event.target;
-    if (!target) {
-      return;
-    }
-    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
-      logDebug("Favorites toggle", { active: target.checked });
-      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : void 0);
-      return;
-    }
-    if (equalityFields.includes(target.name)) {
-      logDebug("Equality filter", { field: target.name, value: target.value });
-      table.getColumn(target.name)?.setFilterValue(target.value || void 0);
-    }
-  }
-  function handleReset() {
-    window.setTimeout(() => {
-      logDebug("Form reset requested");
-      table.resetGlobalFilter();
-      table.resetColumnFilters();
-      render();
-    }, 0);
-  }
-  const handleSubmit = (event) => event.preventDefault();
-  form?.addEventListener("submit", handleSubmit);
-  form?.addEventListener("input", handleInput);
-  form?.addEventListener("change", handleChange);
-  form?.addEventListener("reset", handleReset);
-  const favoritesPayload = loadFavorites();
-  applyFavorites(favoritesPayload.items);
-  const cleanupFavorites = subscribeToFavorites((detail) => {
-    if (!detail?.payload) {
-      return;
-    }
-    applyFavorites(detail.payload.items);
+  const cleanupFunctions = [];
+  const cleanupFavorites = initFavoritesSync({
+    resourceRows,
+    logDebug,
+    updateDataAndRender
   });
-  if (typeof window !== "undefined" && window.location.search) {
-    const params = new URL(window.location.href).searchParams;
-    const applyQueue = [];
-    if (form) {
-      if (searchField) {
-        const queryValue = params.get(searchField);
-        if (queryValue != null) {
-          const input = form.elements.namedItem(searchField);
-          if (input && "value" in input) {
-            input.value = queryValue;
-            applyQueue.push(() => table.setGlobalFilter(queryValue));
-          }
-        }
-      }
-      equalityFields.forEach((field) => {
-        const value = params.get(field);
-        if (value != null) {
-          const element = form.elements.namedItem(field);
-          if (element && "value" in element) {
-            element.value = value;
-            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
-          }
-        }
-      });
-      if (favoritesField && params.has(favoritesField)) {
-        const favoritesInput = form.elements.namedItem(favoritesField);
-        if (favoritesInput instanceof HTMLInputElement) {
-          favoritesInput.checked = true;
-          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
-        }
-      }
-    }
-    applyQueue.forEach((fn) => fn());
-    if (params.toString()) {
-      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
-      window.history.replaceState({}, document.title, nextUrl);
-    }
+  cleanupFunctions.push(cleanupFavorites);
+  const { cleanup: cleanupFilters, syncFiltersFromForm } = initFilterControls({
+    form,
+    table,
+    searchField,
+    favoritesField,
+    equalityFields,
+    logDebug,
+    onFiltersReset: updateStateAndRender
+  });
+  cleanupFunctions.push(cleanupFilters);
+  if (!form) {
+    updateStateAndRender();
+  } else {
+    syncFiltersFromForm();
+    updateStateAndRender();
   }
-  syncFiltersFromForm();
-  updateStateAndRender();
   logDebug("Table initialised", {
     rows: resourceRows.length,
     equalityFields,
@@ -3245,11 +3295,7 @@ function setupResourceTable(options2) {
     favoritesField
   });
   return () => {
-    form?.removeEventListener("submit", handleSubmit);
-    form?.removeEventListener("input", handleInput);
-    form?.removeEventListener("change", handleChange);
-    form?.removeEventListener("reset", handleReset);
-    cleanupFavorites?.();
+    cleanupFunctions.forEach((cleanup2) => cleanup2());
   };
 }
 

--- a/src/scripts/resource-table.client.ts
+++ b/src/scripts/resource-table.client.ts
@@ -1,6 +1,7 @@
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type Table,
   type TableState,
   createColumnHelper,
   createTable,
@@ -48,6 +49,8 @@ interface ResourceRow extends Record<string, string> {
 const DEFAULT_FORM_SELECTOR = ".filter-form";
 const DEFAULT_FAVORITES_FIELD = "favoritesOnly";
 
+type ResourceTableInstance = Table<ResourceRow>;
+
 function toDatasetRecord(dataset: DOMStringMap): Record<string, string> {
   return Object.fromEntries(
     Object.entries(dataset).map(([key, value]) => [key, value ?? ""])
@@ -71,6 +74,246 @@ function normalize(value: unknown): string {
 
 function extractText(card: HTMLLIElement, selector: string): string {
   return card.querySelector<HTMLElement>(selector)?.textContent?.trim() ?? "";
+}
+
+function buildResourceRows(
+  cards: HTMLLIElement[],
+  columns: ResourceColumnConfig[]
+): ResourceRow[] {
+  return cards.map((card, index) => {
+    const dataset = toDatasetRecord(card.dataset);
+    const favoriteRoot = card.querySelector<HTMLElement>("[data-favorite-root]") ?? null;
+    const favoriteButton = favoriteRoot?.querySelector<HTMLButtonElement>(
+      "[data-favorite-button]"
+    ) ?? null;
+    const favoriteKey = favoriteRoot?.dataset.favoriteKey ?? "";
+
+    const fallbackId = dataset.resourceId || card.id || `resource-${index}`;
+    const row: ResourceRow = {
+      id: fallbackId,
+      favorite: dataset.favorite ?? card.dataset.favorite ?? "false",
+      cardElement: card,
+      favoriteRoot,
+      favoriteButton,
+      favoriteKey,
+    };
+
+    columns.forEach((config) => {
+      if (config.key in row) {
+        return;
+      }
+      const datasetValue = dataset[config.key];
+      if (datasetValue) {
+        row[config.key] = datasetValue;
+        return;
+      }
+      if (config.fallback) {
+        row[config.key] = normalize(config.fallback(card));
+        return;
+      }
+      if (config.fallbackSelector) {
+        row[config.key] = extractText(card, config.fallbackSelector);
+        return;
+      }
+      if (config.key === "content") {
+        row.content = card.textContent?.trim() ?? "";
+      } else {
+        row[config.key] = "";
+      }
+    });
+
+    if (!row.name) {
+      row.name = extractText(card, ".resource-card__title");
+    }
+    if (!row.description) {
+      row.description = extractText(card, ".resource-card__summary");
+    }
+    if (!row.content) {
+      row.content = card.textContent?.trim() ?? "";
+    }
+
+    return row;
+  });
+}
+
+interface FavoritesSyncOptions {
+  resourceRows: ResourceRow[];
+  logDebug: (message: string, detail?: unknown) => void;
+  updateDataAndRender: () => void;
+}
+
+function initFavoritesSync({
+  resourceRows,
+  logDebug,
+  updateDataAndRender,
+}: FavoritesSyncOptions): () => void {
+  const applyFavorites = (payload: FavoritesPayload["items"]) => {
+    resourceRows.forEach((row) => {
+      const stored = row.favoriteKey ? payload[row.favoriteKey] : undefined;
+      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
+      row.favorite = isFavorite ? "true" : "false";
+      row.cardElement.dataset.favorite = row.favorite;
+      if (row.favoriteRoot) {
+        row.favoriteRoot.dataset.favorite = row.favorite;
+      }
+      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
+    });
+    logDebug("Favorites applied", {
+      favorites: Object.keys(payload ?? {}).length,
+    });
+    updateDataAndRender();
+  };
+
+  const favoritesPayload = loadFavorites();
+  applyFavorites(favoritesPayload.items);
+
+  const cleanupFavorites = subscribeToFavorites((detail) => {
+    if (!detail?.payload) {
+      return;
+    }
+    applyFavorites(detail.payload.items);
+  });
+
+  return typeof cleanupFavorites === "function" ? cleanupFavorites : () => {};
+}
+
+interface FilterControlOptions {
+  form: HTMLFormElement | null;
+  table: ResourceTableInstance;
+  searchField?: string;
+  favoritesField?: string;
+  equalityFields: string[];
+  logDebug: (message: string, detail?: unknown) => void;
+  onFiltersReset: () => void;
+}
+
+interface FilterControlResult {
+  cleanup: () => void;
+  syncFiltersFromForm: () => void;
+}
+
+function initFilterControls({
+  form,
+  table,
+  searchField,
+  favoritesField,
+  equalityFields,
+  logDebug,
+  onFiltersReset,
+}: FilterControlOptions): FilterControlResult {
+  const syncFiltersFromForm = () => {
+    if (!form) {
+      return;
+    }
+    const formData = new FormData(form);
+    const query = searchField
+      ? (formData.get(searchField) ?? "").toString().trim()
+      : "";
+    if (searchField) {
+      table.setGlobalFilter(query);
+    }
+
+    equalityFields.forEach((field) => {
+      const value = (formData.get(field) ?? "").toString().trim();
+      table.getColumn(field)?.setFilterValue(value || undefined);
+    });
+
+    if (favoritesField) {
+      const favoritesOnly = formData.get(favoritesField) != null;
+      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : undefined);
+    }
+  };
+
+  function handleInput(event: Event) {
+    if (!searchField) return;
+    const target = event.target as HTMLInputElement | null;
+    if (!target || target.name !== searchField) {
+      return;
+    }
+    logDebug("Search input", { value: target.value });
+    table.setGlobalFilter(target.value);
+  }
+
+  function handleChange(event: Event) {
+    const target = event.target as HTMLInputElement | HTMLSelectElement | null;
+    if (!target) {
+      return;
+    }
+    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
+      logDebug("Favorites toggle", { active: target.checked });
+      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : undefined);
+      return;
+    }
+    if (equalityFields.includes(target.name)) {
+      logDebug("Equality filter", { field: target.name, value: target.value });
+      table.getColumn(target.name)?.setFilterValue(target.value || undefined);
+    }
+  }
+
+  function handleReset() {
+    window.setTimeout(() => {
+      logDebug("Form reset requested");
+      table.resetGlobalFilter();
+      table.resetColumnFilters();
+      onFiltersReset();
+    }, 0);
+  }
+
+  const handleSubmit = (event: Event) => event.preventDefault();
+
+  form?.addEventListener("submit", handleSubmit);
+  form?.addEventListener("input", handleInput);
+  form?.addEventListener("change", handleChange);
+  form?.addEventListener("reset", handleReset);
+
+  if (typeof window !== "undefined" && window.location.search) {
+    const params = new URL(window.location.href).searchParams;
+    const applyQueue: Array<() => void> = [];
+    if (form) {
+      if (searchField) {
+        const queryValue = params.get(searchField);
+        if (queryValue != null) {
+          const input = form.elements.namedItem(searchField);
+          if (input && "value" in input) {
+            (input as HTMLInputElement | HTMLSelectElement).value = queryValue;
+            applyQueue.push(() => table.setGlobalFilter(queryValue));
+          }
+        }
+      }
+      equalityFields.forEach((field) => {
+        const value = params.get(field);
+        if (value != null) {
+          const element = form.elements.namedItem(field);
+          if (element && "value" in element) {
+            (element as HTMLInputElement | HTMLSelectElement).value = value;
+            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
+          }
+        }
+      });
+      if (favoritesField && params.has(favoritesField)) {
+        const favoritesInput = form.elements.namedItem(favoritesField);
+        if (favoritesInput instanceof HTMLInputElement) {
+          favoritesInput.checked = true;
+          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
+        }
+      }
+    }
+    applyQueue.forEach((fn) => fn());
+    if (params.toString()) {
+      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }
+
+  return {
+    cleanup: () => {
+      form?.removeEventListener("submit", handleSubmit);
+      form?.removeEventListener("input", handleInput);
+      form?.removeEventListener("change", handleChange);
+      form?.removeEventListener("reset", handleReset);
+    },
+    syncFiltersFromForm,
+  };
 }
 
 export function setupResourceTable(options: ResourceTableOptions): () => void {
@@ -128,61 +371,7 @@ export function setupResourceTable(options: ResourceTableOptions): () => void {
       })
   );
 
-  const resourceRows: ResourceRow[] = cards.map((card, index) => {
-    const dataset = toDatasetRecord(card.dataset);
-    const favoriteRoot = card.querySelector<HTMLElement>("[data-favorite-root]") ?? null;
-    const favoriteButton = favoriteRoot?.querySelector<HTMLButtonElement>(
-      "[data-favorite-button]"
-    ) ?? null;
-    const favoriteKey = favoriteRoot?.dataset.favoriteKey ?? "";
-
-    const fallbackId =
-      dataset.resourceId || card.id || `resource-${index}`;
-    const row: ResourceRow = {
-      id: fallbackId,
-      favorite: dataset.favorite ?? card.dataset.favorite ?? "false",
-      cardElement: card,
-      favoriteRoot,
-      favoriteButton,
-      favoriteKey,
-    };
-
-    columns.forEach((config) => {
-      if (config.key in row) {
-        return;
-      }
-      const datasetValue = dataset[config.key];
-      if (datasetValue) {
-        row[config.key] = datasetValue;
-        return;
-      }
-      if (config.fallback) {
-        row[config.key] = normalize(config.fallback(card));
-        return;
-      }
-      if (config.fallbackSelector) {
-        row[config.key] = extractText(card, config.fallbackSelector);
-        return;
-      }
-      if (config.key === "content") {
-        row.content = card.textContent?.trim() ?? "";
-      } else {
-        row[config.key] = "";
-      }
-    });
-
-    if (!row.name) {
-      row.name = extractText(card, ".resource-card__title");
-    }
-    if (!row.description) {
-      row.description = extractText(card, ".resource-card__summary");
-    }
-    if (!row.content) {
-      row.content = card.textContent?.trim() ?? "";
-    }
-
-    return row;
-  });
+  const resourceRows = buildResourceRows(cards, columns);
 
   const emptyMessage = list.parentElement?.querySelector<HTMLElement>(
     "[data-resource-empty]"
@@ -266,140 +455,32 @@ export function setupResourceTable(options: ResourceTableOptions): () => void {
     render();
   }
 
-  function applyFavorites(payload: FavoritesPayload["items"]) {
-    resourceRows.forEach((row) => {
-      const stored = row.favoriteKey ? payload[row.favoriteKey] : undefined;
-      const isFavorite = Boolean(stored) || row.cardElement.dataset.favorite === "true";
-      row.favorite = isFavorite ? "true" : "false";
-      row.cardElement.dataset.favorite = row.favorite;
-      if (row.favoriteRoot) {
-        row.favoriteRoot.dataset.favorite = row.favorite;
-      }
-      row.favoriteButton?.setAttribute("aria-pressed", String(isFavorite));
-    });
-    logDebug("Favorites applied", {
-      favorites: Object.keys(payload ?? {}).length,
-    });
-    updateDataAndRender();
-  }
+  const cleanupFunctions: Array<() => void> = [];
 
-  function syncFiltersFromForm() {
-    if (!form) {
-      updateStateAndRender();
-      return;
-    }
-    const formData = new FormData(form);
-    const query = searchField
-      ? (formData.get(searchField) ?? "").toString().trim()
-      : "";
-    if (searchField) {
-      table.setGlobalFilter(query);
-    }
-
-    equalityFields.forEach((field) => {
-      const value = (formData.get(field) ?? "").toString().trim();
-      table.getColumn(field)?.setFilterValue(value || undefined);
-    });
-
-    if (favoritesField) {
-      const favoritesOnly = formData.get(favoritesField) != null;
-      table.getColumn("favorite")?.setFilterValue(favoritesOnly ? "true" : undefined);
-    }
-  }
-
-  function handleInput(event: Event) {
-    if (!searchField) return;
-    const target = event.target as HTMLInputElement | null;
-    if (!target || target.name !== searchField) {
-      return;
-    }
-    logDebug("Search input", { value: target.value });
-    table.setGlobalFilter(target.value);
-  }
-
-  function handleChange(event: Event) {
-    const target = event.target as HTMLInputElement | HTMLSelectElement | null;
-    if (!target) {
-      return;
-    }
-    if (favoritesField && target.name === favoritesField && target instanceof HTMLInputElement) {
-      logDebug("Favorites toggle", { active: target.checked });
-      table.getColumn("favorite")?.setFilterValue(target.checked ? "true" : undefined);
-      return;
-    }
-    if (equalityFields.includes(target.name)) {
-      logDebug("Equality filter", { field: target.name, value: target.value });
-      table.getColumn(target.name)?.setFilterValue(target.value || undefined);
-    }
-  }
-
-  function handleReset() {
-    window.setTimeout(() => {
-      logDebug("Form reset requested");
-      table.resetGlobalFilter();
-      table.resetColumnFilters();
-      render();
-    }, 0);
-  }
-
-  const handleSubmit = (event: Event) => event.preventDefault();
-
-  form?.addEventListener("submit", handleSubmit);
-  form?.addEventListener("input", handleInput);
-  form?.addEventListener("change", handleChange);
-  form?.addEventListener("reset", handleReset);
-
-  const favoritesPayload = loadFavorites();
-  applyFavorites(favoritesPayload.items);
-
-  const cleanupFavorites = subscribeToFavorites((detail) => {
-    if (!detail?.payload) {
-      return;
-    }
-    applyFavorites(detail.payload.items);
+  const cleanupFavorites = initFavoritesSync({
+    resourceRows,
+    logDebug,
+    updateDataAndRender,
   });
+  cleanupFunctions.push(cleanupFavorites);
 
-  if (typeof window !== "undefined" && window.location.search) {
-    const params = new URL(window.location.href).searchParams;
-    const applyQueue: Array<() => void> = [];
-    if (form) {
-      if (searchField) {
-        const queryValue = params.get(searchField);
-        if (queryValue != null) {
-          const input = form.elements.namedItem(searchField);
-          if (input && "value" in input) {
-            (input as HTMLInputElement | HTMLSelectElement).value = queryValue;
-            applyQueue.push(() => table.setGlobalFilter(queryValue));
-          }
-        }
-      }
-      equalityFields.forEach((field) => {
-        const value = params.get(field);
-        if (value != null) {
-          const element = form.elements.namedItem(field);
-          if (element && "value" in element) {
-            (element as HTMLInputElement | HTMLSelectElement).value = value;
-            applyQueue.push(() => table.getColumn(field)?.setFilterValue(value));
-          }
-        }
-      });
-      if (favoritesField && params.has(favoritesField)) {
-        const favoritesInput = form.elements.namedItem(favoritesField);
-        if (favoritesInput instanceof HTMLInputElement) {
-          favoritesInput.checked = true;
-          applyQueue.push(() => table.getColumn("favorite")?.setFilterValue("true"));
-        }
-      }
-    }
-    applyQueue.forEach((fn) => fn());
-    if (params.toString()) {
-      const nextUrl = `${window.location.pathname}${window.location.hash ?? ""}`;
-      window.history.replaceState({}, document.title, nextUrl);
-    }
+  const { cleanup: cleanupFilters, syncFiltersFromForm } = initFilterControls({
+    form,
+    table,
+    searchField,
+    favoritesField,
+    equalityFields,
+    logDebug,
+    onFiltersReset: updateStateAndRender,
+  });
+  cleanupFunctions.push(cleanupFilters);
+
+  if (!form) {
+    updateStateAndRender();
+  } else {
+    syncFiltersFromForm();
+    updateStateAndRender();
   }
-
-  syncFiltersFromForm();
-  updateStateAndRender();
 
   logDebug("Table initialised", {
     rows: resourceRows.length,
@@ -409,10 +490,6 @@ export function setupResourceTable(options: ResourceTableOptions): () => void {
   });
 
   return () => {
-    form?.removeEventListener("submit", handleSubmit);
-    form?.removeEventListener("input", handleInput);
-    form?.removeEventListener("change", handleChange);
-    form?.removeEventListener("reset", handleReset);
-    cleanupFavorites?.();
+    cleanupFunctions.forEach((cleanup) => cleanup());
   };
 }


### PR DESCRIPTION
## Summary
- extract resource row construction into a pure `buildResourceRows` helper
- move favorites synchronization and filter wiring into dedicated helpers that expose cleanup callbacks
- streamline `setupResourceTable` to compose the new helpers while preserving rendering behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd26e60e3c832a9208e611bfc47442